### PR TITLE
Convert Navigation Controller to Optional

### DIFF
--- a/OAuth2/OAuth2WebViewController.swift
+++ b/OAuth2/OAuth2WebViewController.swift
@@ -40,7 +40,7 @@ extension OAuth2 {
 		}
 		
 		let navi = UINavigationController(rootViewController: web)
-		from.presentViewController(navi, animated: true, completion: nil)
+		from.presentViewController(navi!, animated: true, completion: nil)
 		
 		return web
 	}


### PR DESCRIPTION
It appears the api changed, at least according to my xcode source highlighting.
