### PR TITLE
Rename OAuth2Password to OAuth2PasswordGrant

### DIFF
--- a/OAuth2 Tests/OAuth2PasswordGrant_Tests.swift
+++ b/OAuth2 Tests/OAuth2PasswordGrant_Tests.swift
@@ -22,8 +22,8 @@ import OAuth2
 
 class OAuth2PasswordGrantTests: XCTestCase{
 	
-	func genericOAuth2Password() -> OAuth2Password {
-		return OAuth2Password(settings: [
+	func genericOAuth2Password() -> OAuth2PasswordGrant {
+		return OAuth2PasswordGrant(settings: [
 			"client_id": "abc",
 			"client_secret": "def",
 			"authorize_uri": "https://auth.ful.io",
@@ -60,7 +60,7 @@ class OAuth2PasswordGrantTests: XCTestCase{
 	}
 	
 	func testTokenRequestNoScope() {
-		let oauth = OAuth2Password(settings: [
+		let oauth = OAuth2PasswordGrant(settings: [
 			"client_id": "abc",
 			"client_secret": "def",
 			"authorize_uri": "https://auth.ful.io",

--- a/OAuth2/OAuth2PasswordGrant.swift
+++ b/OAuth2/OAuth2PasswordGrant.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-public class OAuth2Password: OAuth2
+public class OAuth2PasswordGrant: OAuth2
 {
 	public var username: String
 	


### PR DESCRIPTION
I didn't realize I missed this. I went back and forth and settled on OAuth2PasswordGrant as the class name, changed the file name but not the class.