### PR TITLE
Remove 'state' parameter from token endpoint request.

### DIFF
--- a/OAuth2/OAuth2.swift
+++ b/OAuth2/OAuth2.swift
@@ -307,7 +307,7 @@ public class OAuth2: OAuth2Base
 	the query part
 	- returns: NSURL to be used to start the OAuth dance
 	*/
-	public func authorizeURLWithBase(base: NSURL, redirect: String?, scope: String?, responseType: String?, params: [String: String]?) throws -> NSURL {
+	public func authorizeURLWithBase(base: NSURL, redirect: String?, scope: String?, responseType: String?, params: [String: String]?, isTokenRequest: Bool = false) throws -> NSURL {
 		
 		// verify that we have all parts
 		if clientId.isEmpty {
@@ -333,7 +333,10 @@ public class OAuth2: OAuth2Base
 		var urlParams = params ?? [String: String]()
 		urlParams["client_id"] = clientId
 		urlParams["redirect_uri"] = self.redirect!
-		urlParams["state"] = context.state
+		
+		if !isTokenRequest {
+			urlParams["state"] = context.state
+		}
 		
 		if nil != scope {
 			self.scope = scope!

--- a/OAuth2/OAuth2CodeGrant.swift
+++ b/OAuth2/OAuth2CodeGrant.swift
@@ -162,7 +162,7 @@ public class OAuth2CodeGrant: OAuth2
 			urlParams["client_secret"] = secret
 		}
 		
-		return try authorizeURLWithBase(tokenURL ?? authURL, redirect: redirect, scope: nil, responseType: nil, params: urlParams)
+		return try authorizeURLWithBase(tokenURL ?? authURL, redirect: redirect, scope: nil, responseType: nil, params: urlParams, isTokenRequest: true)
 	}
 	
 	/**
@@ -257,7 +257,7 @@ public class OAuth2CodeGrant: OAuth2
 			urlParams["client_secret"] = secret
 		}
 		
-		return try authorizeURLWithBase(tokenURL ?? authURL, redirect: redirect, scope: nil, responseType: nil, params: urlParams)
+		return try authorizeURLWithBase(tokenURL ?? authURL, redirect: redirect, scope: nil, responseType: nil, params: urlParams, isTokenRequest: true)
 	}
 	
 	/**


### PR DESCRIPTION
According to [RFC](https://tools.ietf.org/html/rfc6749#section-4.1.3), Access Token Requests are not allowed to include 'state' parameter. 
This PR removes 'state' parameter from the access token requests.

