### PR TITLE
added a fix for the AlamoFire example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,11 @@ extension OAuth2 {
         headers: [String: String]? = nil)
         -> Alamofire.Request
     {
-        var hdrs = headers
-        hdrs["Authorization"] = "Bearer \(accessToken)"
+        
+        var hdrs = headers ?? [:]
+        if let token = accessToken {
+            hdrs["Authorization"] = "Bearer \(token)"
+        }
         return Alamofire.request(
             method,
             URLString,


### PR DESCRIPTION
changes to the AlamoFire example to make it safe for empty header dictionary inputs as well as optional binding for accessToken insertion into the header dictionary