### PR TITLE
Implemented embedded auth flow for OS X

### DIFF
--- a/OAuth2+OSX/OAuth2+OSX.swift
+++ b/OAuth2+OSX/OAuth2+OSX.swift
@@ -24,11 +24,11 @@ import Cocoa
 extension OAuth2
 {
 	/**
-	    Uses `NSWorkspace` to open the authorize URL in the OS browser.
+	Uses `NSWorkspace` to open the authorize URL in the OS browser.
 	
-	    - parameter params: Additional parameters to pass to the authorize URL
-	    :returs: A bool indicating success
-	 */
+	- parameter params: Additional parameters to pass to the authorize URL
+	:returs: A bool indicating success
+	*/
 	public final func openAuthorizeURLInBrowser(params: OAuth2StringDict? = nil) -> Bool {
 		do {
 			let url = try authorizeURL(params)
@@ -42,75 +42,75 @@ extension OAuth2
 	
 	
 	// MARK: - Embedded View
-    
-	/**
-	    Tries to use the given context, which on OS X should be a NSViewController, to present the authorization screen.
 	
-	    - returns: A bool indicating whether the method was able to show the authorize screen
-	 */
+	/**
+	Tries to use the given context, which on OS X should be a NSViewController, to present the authorization screen.
+	
+	- returns: A bool indicating whether the method was able to show the authorize screen
+	*/
 	public func authorizeEmbeddedWith(config: OAuth2AuthConfig, params: OAuth2StringDict? = nil, autoDismiss: Bool = true) -> Bool {
-        guard #available(OSX 10.11, *) else {
-            logIfVerbose("authorizeEmbedded is only available for OS X 10.11 and later")
-            return false
-        }
-        
-        let controller = OAuth2WebViewController()
-        controller.interceptURLString = redirect
-        controller.onIntercept = { url in
-            do {
-                try self.handleRedirectURL(url)
-                return true
-            }
-            catch let err {
-                self.logIfVerbose("Cannot intercept redirect URL: \(err)")
-            }
-            return false
-        }
-        controller.onWillDismiss = { didCancel in
-            if didCancel {
-                self.didFail(nil)
-            }
-        }
-        
-        if let presentationBlock = config.authorizePresentationBlock {
-            presentationBlock(webViewController: controller)
-            return true
-        }
-        
-        let window = NSWindow(contentRect: NSMakeRect(0, 0, OAuth2WebViewController.WebViewWindowWidth, OAuth2WebViewController.WebViewWindowHeight), styleMask: NSTitledWindowMask|NSClosableWindowMask|NSFullSizeContentViewWindowMask, backing: .Buffered, `defer`: false)
-        window.backgroundColor = NSColor.whiteColor()
-        window.movableByWindowBackground = true
-        window.titlebarAppearsTransparent = true
-        window.titleVisibility = .Hidden
-        window.animationBehavior = .AlertPanel
-        if let title = config.ui.title {
-            window.title = title
-        }
-        let windowController = NSWindowController(window: window)
-        embeddedUI = windowController
-        windowController.contentViewController = controller
-        windowController.window?.center()
-        windowController.showWindow(nil)
-
-        do {
-            let url = try authorizeURL(params)
-            controller.startURL = url
-        } catch let err {
-            logIfVerbose("Cannot get authorize URL for embedded authorization: \(err)")
-            return false
-        }
-        
-        if autoDismiss {
-            internalAfterAuthorizeOrFailure = { wasFailure, error in
-                if !wasFailure {
-                    windowController.close()
-                }
-                
-                self.embeddedUI = nil
-            }
-        }
-
-        return true
+		guard #available(OSX 10.11, *) else {
+			logIfVerbose("authorizeEmbedded is only available for OS X 10.11 and later")
+			return false
+		}
+		
+		let controller = OAuth2WebViewController()
+		controller.interceptURLString = redirect
+		controller.onIntercept = { url in
+			do {
+				try self.handleRedirectURL(url)
+				return true
+			}
+			catch let err {
+				self.logIfVerbose("Cannot intercept redirect URL: \(err)")
+			}
+			return false
+		}
+		controller.onWillDismiss = { didCancel in
+			if didCancel {
+				self.didFail(nil)
+			}
+		}
+		
+		if let presentationBlock = config.authorizeContext {
+			presentationBlock(webViewController: controller)
+			return true
+		}
+		
+		let window = NSWindow(contentRect: NSMakeRect(0, 0, OAuth2WebViewController.WebViewWindowWidth, OAuth2WebViewController.WebViewWindowHeight), styleMask: NSTitledWindowMask|NSClosableWindowMask|NSFullSizeContentViewWindowMask, backing: .Buffered, `defer`: false)
+		window.backgroundColor = NSColor.whiteColor()
+		window.movableByWindowBackground = true
+		window.titlebarAppearsTransparent = true
+		window.titleVisibility = .Hidden
+		window.animationBehavior = .AlertPanel
+		if let title = config.ui.title {
+			window.title = title
+		}
+		let windowController = NSWindowController(window: window)
+		embeddedUI = windowController
+		windowController.contentViewController = controller
+		windowController.window?.center()
+		windowController.showWindow(nil)
+		
+		do {
+			let url = try authorizeURL(params)
+			controller.startURL = url
+		} catch let err {
+			logIfVerbose("Cannot get authorize URL for embedded authorization: \(err)")
+			return false
+		}
+		
+		if autoDismiss {
+			internalAfterAuthorizeOrFailure = { wasFailure, error in
+				if !wasFailure {
+					windowController.close()
+				}
+				
+				self.embeddedUI = nil
+			}
+		}
+		
+		return true
 	}
 	
 	public func authorizeEmbeddedFrom(controller: NSViewController, params: OAuth2StringDict?) -> AnyObject {

--- a/OAuth2+OSX/OAuth2+OSX.swift
+++ b/OAuth2+OSX/OAuth2+OSX.swift
@@ -87,7 +87,7 @@ extension OAuth2
 			window.title = title
 		}
 		let windowController = NSWindowController(window: window)
-		embeddedUI = windowController
+		authConfig.ui.windowController = windowController
 		windowController.contentViewController = controller
 		windowController.window?.center()
 		windowController.showWindow(nil)
@@ -106,7 +106,7 @@ extension OAuth2
 					windowController.close()
 				}
 				
-				self.embeddedUI = nil
+				self.authConfig.ui.windowController = nil
 			}
 		}
 		

--- a/OAuth2+OSX/OAuth2WebViewController.swift
+++ b/OAuth2+OSX/OAuth2WebViewController.swift
@@ -1,0 +1,260 @@
+//
+//  OAuth2WebViewController.swift
+//  OAuth2
+//
+//  Created by Guilherme Rambo on 18/01/16.
+//  Copyright 2014 Pascal Pfiffner
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Cocoa
+import WebKit
+
+
+/**
+    A view controller that allows you to display the login/authorization screen.
+ */
+@available(OSX 10.11, *)
+public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NSWindowDelegate
+{
+    init() {
+        super.init(nibName: nil, bundle: nil)!
+    }
+    
+	/// Handle to the OAuth2 instance in play, only used for debug lugging at this time.
+	var oauth: OAuth2?
+	
+	/// The URL to load on first show.
+	public var startURL: NSURL? {
+		didSet(oldURL) {
+			if nil != startURL && nil == oldURL && viewLoaded {
+				loadURL(startURL!)
+			}
+		}
+	}
+	
+	/// The URL string to intercept and respond to.
+	var interceptURLString: String? {
+		didSet(oldURL) {
+			if nil != interceptURLString {
+				if let url = NSURL(string: interceptURLString!) {
+					interceptComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: true)
+				}
+				else {
+					oauth?.logIfVerbose("Failed to parse URL \(interceptURLString), discarding")
+					interceptURLString = nil
+				}
+			}
+			else {
+				interceptComponents = nil
+			}
+		}
+	}
+	var interceptComponents: NSURLComponents?
+	
+	/// Closure called when the web view gets asked to load the redirect URL, specified in `interceptURLString`. Return a Bool indicating
+	/// that you've intercepted the URL.
+	var onIntercept: ((url: NSURL) -> Bool)?
+	
+	/// Called when the web view is about to be dismissed.
+	var onWillDismiss: ((didCancel: Bool) -> Void)?
+	
+	/// Our web view; implicitly unwrapped so do not attempt to use it unless isViewLoaded() returns true.
+	var webView: WKWebView!
+	
+    private var progressIndicator: NSProgressIndicator!
+    private var loadingView: NSView {
+        let view = NSView(frame: self.view.bounds)
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        progressIndicator = NSProgressIndicator(frame: NSZeroRect)
+        progressIndicator.style = .SpinningStyle
+        progressIndicator.displayedWhenStopped = false
+        progressIndicator.sizeToFit()
+        progressIndicator.translatesAutoresizingMaskIntoConstraints = false
+        
+        view.addSubview(progressIndicator)
+        progressIndicator.centerXAnchor.constraintEqualToAnchor(view.centerXAnchor).active = true
+        progressIndicator.centerYAnchor.constraintEqualToAnchor(view.centerYAnchor).active = true
+        
+        return view
+    }
+	
+	required public init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+	}
+	
+	
+	// MARK: - View Handling
+	
+    internal static let WebViewWindowWidth = CGFloat(600.0)
+    internal static let WebViewWindowHeight = CGFloat(400.0)
+    
+	override public func loadView() {
+        view = NSView(frame: NSMakeRect(0, 0, OAuth2WebViewController.WebViewWindowWidth, OAuth2WebViewController.WebViewWindowHeight))
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        webView = WKWebView(frame: view.bounds, configuration: WKWebViewConfiguration())
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.navigationDelegate = self
+        webView.alphaValue = 0.0
+        
+        view.addSubview(webView)
+        
+        webView.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
+        webView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor).active = true
+        webView.leadingAnchor.constraintEqualToAnchor(view.leadingAnchor).active = true
+        webView.trailingAnchor.constraintEqualToAnchor(view.trailingAnchor).active = true
+        
+        showLoadingIndicator()
+	}
+	
+	override public func viewWillAppear() {
+		super.viewWillAppear()
+		
+		if !webView.canGoBack {
+			if nil != startURL {
+				loadURL(startURL!)
+			}
+			else {
+				webView.loadHTMLString("There is no `startURL`", baseURL: nil)
+			}
+		}
+	}
+	
+    public override func viewDidAppear() {
+        super.viewDidAppear()
+        
+        view.window?.delegate = self
+    }
+    
+	func showLoadingIndicator() {
+        let loadingContainerView = loadingView
+        
+		view.addSubview(loadingContainerView)
+        loadingContainerView.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
+        loadingContainerView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor).active = true
+        loadingContainerView.leadingAnchor.constraintEqualToAnchor(view.leadingAnchor).active = true
+        loadingContainerView.trailingAnchor.constraintEqualToAnchor(view.trailingAnchor).active = true
+
+        progressIndicator.startAnimation(nil)
+	}
+	
+	func hideLoadingIndicator() {
+        guard progressIndicator != nil else { return }
+        
+        progressIndicator.stopAnimation(nil)
+        progressIndicator.superview?.removeFromSuperview()
+	}
+
+	func showErrorMessage(message: String, animated: Bool) {
+        hideLoadingIndicator()
+        webView.animator().alphaValue = 1.0
+        webView.loadHTMLString("<p style=\"text-align:center;font:'helvetica neue', sans-serif;color:red\">\(message)</p>", baseURL: nil)
+	}
+	
+	// MARK: - Actions
+	
+	public func loadURL(url: NSURL) {
+		webView.loadRequest(NSURLRequest(URL: url))
+	}
+	
+	func goBack(sender: AnyObject?) {
+		webView.goBack()
+	}
+	
+	func cancel(sender: AnyObject?) {
+		dismiss(asCancel: true, animated: nil != sender ? true : false)
+	}
+	
+	func dismiss(animated animated: Bool) {
+		dismiss(asCancel: false, animated: animated)
+	}
+	
+	func dismiss(asCancel asCancel: Bool, animated: Bool) {
+		webView.stopLoading()
+		
+        onWillDismiss?(didCancel: asCancel)
+        
+        dismissViewController(self)
+	}
+	
+	
+	// MARK: - Web View Delegate
+	
+    public func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
+        let request = navigationAction.request
+        
+		if nil == onIntercept {
+            decisionHandler(.Allow)
+			return
+		}
+
+		// we compare the scheme and host first, then check the path (if there is any). Not sure if a simple string comparison
+		// would work as there may be URL parameters attached
+		if let url = request.URL where url.scheme == interceptComponents?.scheme && url.host == interceptComponents?.host {
+			let haveComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: true)
+			if let hp = haveComponents?.path, ip = interceptComponents?.path where hp == ip || ("/" == hp + ip) {
+                if onIntercept!(url: url) {
+                    decisionHandler(.Cancel)
+                } else {
+                    decisionHandler(.Allow)
+                }
+			}
+		}
+		
+        decisionHandler(.Allow)
+    }
+
+    private var gotIntercepted = false
+    
+    public func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
+		if let scheme = interceptComponents?.scheme where "urn" == scheme {
+			if let path = interceptComponents?.path where path.hasPrefix("ietf:wg:oauth:2.0:oob") {
+				if let title = webView.title where title.hasPrefix("Success ") {
+					oauth?.logIfVerbose("Creating redirect URL from document.title")
+					let qry = title.stringByReplacingOccurrencesOfString("Success ", withString: "")
+					if let url = NSURL(string: "http://localhost/?\(qry)") {
+                        gotIntercepted = true
+						onIntercept?(url: url)
+						return
+					}
+					else {
+						oauth?.logIfVerbose("Failed to create a URL with query parts \"\(qry)\"")
+					}
+				}
+			}
+		}
+		
+        webView.animator().alphaValue = 1.0
+		hideLoadingIndicator()
+    }
+    
+    public func webView(webView: WKWebView, didFailNavigation navigation: WKNavigation!, withError error: NSError) {
+		if NSURLErrorDomain == error.domain && NSURLErrorCancelled == error.code {
+			return
+		}
+		// do we still need to intercept "WebKitErrorDomain" error 102?
+        
+        showErrorMessage(error.localizedDescription, animated: true)
+    }
+    
+    // MARK: - Window Delegate
+    
+    public func windowWillClose(notification: NSNotification) {
+        onWillDismiss?(didCancel: !gotIntercepted)
+    }
+
+}
+

--- a/OAuth2+OSX/OAuth2WebViewController.swift
+++ b/OAuth2+OSX/OAuth2WebViewController.swift
@@ -23,15 +23,15 @@ import WebKit
 
 
 /**
-    A view controller that allows you to display the login/authorization screen.
- */
+A view controller that allows you to display the login/authorization screen.
+*/
 @available(OSX 10.11, *)
 public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NSWindowDelegate
 {
-    init() {
-        super.init(nibName: nil, bundle: nil)!
-    }
-    
+	init() {
+		super.init(nibName: nil, bundle: nil)!
+	}
+	
 	/// Handle to the OAuth2 instance in play, only used for debug lugging at this time.
 	var oauth: OAuth2?
 	
@@ -73,23 +73,23 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 	/// Our web view; implicitly unwrapped so do not attempt to use it unless isViewLoaded() returns true.
 	var webView: WKWebView!
 	
-    private var progressIndicator: NSProgressIndicator!
-    private var loadingView: NSView {
-        let view = NSView(frame: self.view.bounds)
-        view.translatesAutoresizingMaskIntoConstraints = false
-
-        progressIndicator = NSProgressIndicator(frame: NSZeroRect)
-        progressIndicator.style = .SpinningStyle
-        progressIndicator.displayedWhenStopped = false
-        progressIndicator.sizeToFit()
-        progressIndicator.translatesAutoresizingMaskIntoConstraints = false
-        
-        view.addSubview(progressIndicator)
-        progressIndicator.centerXAnchor.constraintEqualToAnchor(view.centerXAnchor).active = true
-        progressIndicator.centerYAnchor.constraintEqualToAnchor(view.centerYAnchor).active = true
-        
-        return view
-    }
+	private var progressIndicator: NSProgressIndicator!
+	private var loadingView: NSView {
+		let view = NSView(frame: self.view.bounds)
+		view.translatesAutoresizingMaskIntoConstraints = false
+		
+		progressIndicator = NSProgressIndicator(frame: NSZeroRect)
+		progressIndicator.style = .SpinningStyle
+		progressIndicator.displayedWhenStopped = false
+		progressIndicator.sizeToFit()
+		progressIndicator.translatesAutoresizingMaskIntoConstraints = false
+		
+		view.addSubview(progressIndicator)
+		progressIndicator.centerXAnchor.constraintEqualToAnchor(view.centerXAnchor).active = true
+		progressIndicator.centerYAnchor.constraintEqualToAnchor(view.centerYAnchor).active = true
+		
+		return view
+	}
 	
 	required public init?(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
@@ -98,26 +98,26 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 	
 	// MARK: - View Handling
 	
-    internal static let WebViewWindowWidth = CGFloat(600.0)
-    internal static let WebViewWindowHeight = CGFloat(400.0)
-    
+	internal static let WebViewWindowWidth = CGFloat(600.0)
+	internal static let WebViewWindowHeight = CGFloat(400.0)
+	
 	override public func loadView() {
-        view = NSView(frame: NSMakeRect(0, 0, OAuth2WebViewController.WebViewWindowWidth, OAuth2WebViewController.WebViewWindowHeight))
-        view.translatesAutoresizingMaskIntoConstraints = false
-
-        webView = WKWebView(frame: view.bounds, configuration: WKWebViewConfiguration())
-        webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.navigationDelegate = self
-        webView.alphaValue = 0.0
-        
-        view.addSubview(webView)
-        
-        webView.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
-        webView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor).active = true
-        webView.leadingAnchor.constraintEqualToAnchor(view.leadingAnchor).active = true
-        webView.trailingAnchor.constraintEqualToAnchor(view.trailingAnchor).active = true
-        
-        showLoadingIndicator()
+		view = NSView(frame: NSMakeRect(0, 0, OAuth2WebViewController.WebViewWindowWidth, OAuth2WebViewController.WebViewWindowHeight))
+		view.translatesAutoresizingMaskIntoConstraints = false
+		
+		webView = WKWebView(frame: view.bounds, configuration: WKWebViewConfiguration())
+		webView.translatesAutoresizingMaskIntoConstraints = false
+		webView.navigationDelegate = self
+		webView.alphaValue = 0.0
+		
+		view.addSubview(webView)
+		
+		webView.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
+		webView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor).active = true
+		webView.leadingAnchor.constraintEqualToAnchor(view.leadingAnchor).active = true
+		webView.trailingAnchor.constraintEqualToAnchor(view.trailingAnchor).active = true
+		
+		showLoadingIndicator()
 	}
 	
 	override public func viewWillAppear() {
@@ -133,35 +133,35 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 		}
 	}
 	
-    public override func viewDidAppear() {
-        super.viewDidAppear()
-        
-        view.window?.delegate = self
-    }
-    
+	public override func viewDidAppear() {
+		super.viewDidAppear()
+		
+		view.window?.delegate = self
+	}
+	
 	func showLoadingIndicator() {
-        let loadingContainerView = loadingView
-        
+		let loadingContainerView = loadingView
+		
 		view.addSubview(loadingContainerView)
-        loadingContainerView.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
-        loadingContainerView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor).active = true
-        loadingContainerView.leadingAnchor.constraintEqualToAnchor(view.leadingAnchor).active = true
-        loadingContainerView.trailingAnchor.constraintEqualToAnchor(view.trailingAnchor).active = true
-
-        progressIndicator.startAnimation(nil)
+		loadingContainerView.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
+		loadingContainerView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor).active = true
+		loadingContainerView.leadingAnchor.constraintEqualToAnchor(view.leadingAnchor).active = true
+		loadingContainerView.trailingAnchor.constraintEqualToAnchor(view.trailingAnchor).active = true
+		
+		progressIndicator.startAnimation(nil)
 	}
 	
 	func hideLoadingIndicator() {
-        guard progressIndicator != nil else { return }
-        
-        progressIndicator.stopAnimation(nil)
-        progressIndicator.superview?.removeFromSuperview()
+		guard progressIndicator != nil else { return }
+		
+		progressIndicator.stopAnimation(nil)
+		progressIndicator.superview?.removeFromSuperview()
 	}
-
+	
 	func showErrorMessage(message: String, animated: Bool) {
-        hideLoadingIndicator()
-        webView.animator().alphaValue = 1.0
-        webView.loadHTMLString("<p style=\"text-align:center;font:'helvetica neue', sans-serif;color:red\">\(message)</p>", baseURL: nil)
+		hideLoadingIndicator()
+		webView.animator().alphaValue = 1.0
+		webView.loadHTMLString("<p style=\"text-align:center;font:'helvetica neue', sans-serif;color:red\">\(message)</p>", baseURL: nil)
 	}
 	
 	// MARK: - Actions
@@ -185,48 +185,48 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 	func dismiss(asCancel asCancel: Bool, animated: Bool) {
 		webView.stopLoading()
 		
-        onWillDismiss?(didCancel: asCancel)
-        
-        dismissViewController(self)
+		onWillDismiss?(didCancel: asCancel)
+		
+		dismissViewController(self)
 	}
 	
 	
 	// MARK: - Web View Delegate
 	
-    public func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
-        let request = navigationAction.request
-        
+	public func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
+		let request = navigationAction.request
+		
 		if nil == onIntercept {
-            decisionHandler(.Allow)
+			decisionHandler(.Allow)
 			return
 		}
-
+		
 		// we compare the scheme and host first, then check the path (if there is any). Not sure if a simple string comparison
 		// would work as there may be URL parameters attached
 		if let url = request.URL where url.scheme == interceptComponents?.scheme && url.host == interceptComponents?.host {
 			let haveComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: true)
 			if let hp = haveComponents?.path, ip = interceptComponents?.path where hp == ip || ("/" == hp + ip) {
-                if onIntercept!(url: url) {
-                    decisionHandler(.Cancel)
-                } else {
-                    decisionHandler(.Allow)
-                }
+				if onIntercept!(url: url) {
+					decisionHandler(.Cancel)
+				} else {
+					decisionHandler(.Allow)
+				}
 			}
 		}
 		
-        decisionHandler(.Allow)
-    }
-
-    private var gotIntercepted = false
-    
-    public func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
+		decisionHandler(.Allow)
+	}
+	
+	private var gotIntercepted = false
+	
+	public func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
 		if let scheme = interceptComponents?.scheme where "urn" == scheme {
 			if let path = interceptComponents?.path where path.hasPrefix("ietf:wg:oauth:2.0:oob") {
 				if let title = webView.title where title.hasPrefix("Success ") {
 					oauth?.logIfVerbose("Creating redirect URL from document.title")
 					let qry = title.stringByReplacingOccurrencesOfString("Success ", withString: "")
 					if let url = NSURL(string: "http://localhost/?\(qry)") {
-                        gotIntercepted = true
+						gotIntercepted = true
 						onIntercept?(url: url)
 						return
 					}
@@ -237,24 +237,24 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 			}
 		}
 		
-        webView.animator().alphaValue = 1.0
+		webView.animator().alphaValue = 1.0
 		hideLoadingIndicator()
-    }
-    
-    public func webView(webView: WKWebView, didFailNavigation navigation: WKNavigation!, withError error: NSError) {
+	}
+	
+	public func webView(webView: WKWebView, didFailNavigation navigation: WKNavigation!, withError error: NSError) {
 		if NSURLErrorDomain == error.domain && NSURLErrorCancelled == error.code {
 			return
 		}
 		// do we still need to intercept "WebKitErrorDomain" error 102?
-        
-        showErrorMessage(error.localizedDescription, animated: true)
-    }
-    
-    // MARK: - Window Delegate
-    
-    public func windowWillClose(notification: NSNotification) {
-        onWillDismiss?(didCancel: !gotIntercepted)
-    }
-
+		
+		showErrorMessage(error.localizedDescription, animated: true)
+	}
+	
+	// MARK: - Window Delegate
+	
+	public func windowWillClose(notification: NSNotification) {
+		onWillDismiss?(didCancel: !gotIntercepted)
+	}
+	
 }
 

--- a/OAuth2.xcodeproj/project.pbxproj
+++ b/OAuth2.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DD0CCBAD1C4DC83A0044C4E3 /* OAuth2WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0CCBAC1C4DC83A0044C4E3 /* OAuth2WebViewController.swift */; };
 		EA9758181B222CEA007744B1 /* OAuth2PasswordGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9758171B222CEA007744B1 /* OAuth2PasswordGrant.swift */; };
 		EA97581D1B223A5D007744B1 /* OAuth2PasswordGrant_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA97581B1B223932007744B1 /* OAuth2PasswordGrant_Tests.swift */; };
 		EA97581E1B2242F9007744B1 /* OAuth2PasswordGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9758171B222CEA007744B1 /* OAuth2PasswordGrant.swift */; };
@@ -108,6 +109,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		DD0CCBAC1C4DC83A0044C4E3 /* OAuth2WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2WebViewController.swift; sourceTree = "<group>"; };
 		EA9758171B222CEA007744B1 /* OAuth2PasswordGrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2PasswordGrant.swift; sourceTree = "<group>"; };
 		EA97581B1B223932007744B1 /* OAuth2PasswordGrant_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2PasswordGrant_Tests.swift; sourceTree = "<group>"; };
 		EE1391D91AC5B41A002C7B18 /* OAuth2CodeGrantBasicAuth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2CodeGrantBasicAuth.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 		EEC7A8C51AE46C33008C30E7 /* OAuth2+OSX */ = {
 			isa = PBXGroup;
 			children = (
+				DD0CCBAC1C4DC83A0044C4E3 /* OAuth2WebViewController.swift */,
 				EEC7A8C61AE46C33008C30E7 /* OAuth2+OSX.swift */,
 			);
 			path = "OAuth2+OSX";
@@ -479,6 +482,7 @@
 			files = (
 				EEACE1DC1A7E8DF6009BF3A7 /* extensions.swift in Sources */,
 				EEC7A8D81AE4851E008C30E7 /* Keychain.swift in Sources */,
+				DD0CCBAD1C4DC83A0044C4E3 /* OAuth2WebViewController.swift in Sources */,
 				EEC7A8DE1AE4851E008C30E7 /* KeychainService.swift in Sources */,
 				EE79F65A1BFAA36900746243 /* OAuth2Error.swift in Sources */,
 				EE79F6571BFA945C00746243 /* OAuth2ClientConfig.swift in Sources */,

--- a/OAuth2/OAuth2.swift
+++ b/OAuth2/OAuth2.swift
@@ -228,11 +228,6 @@ public class OAuth2: OAuth2Base {
 		}
 	}
 	
-	#if os(OSX)
-	/// Used to hold a reference to the container (window controller) for embedded authorization on OS X
-	internal var embeddedUI: AnyObject?
-	#endif
-	
 	/**
 	If the instance has an accessToken, checks if its expiry time has not yet passed. If we don't have an expiry date we assume the token
 	is still valid.

--- a/OAuth2/OAuth2.swift
+++ b/OAuth2/OAuth2.swift
@@ -227,6 +227,11 @@ public class OAuth2: OAuth2Base {
 			}
 		}
 	}
+    
+    #if os(OSX)
+    /// Used to hold a reference to the container (window controller) for embedded authorization on OS X
+    internal var embeddedUI: AnyObject?
+    #endif
 	
 	/**
 	If the instance has an accessToken, checks if its expiry time has not yet passed. If we don't have an expiry date we assume the token

--- a/OAuth2/OAuth2.swift
+++ b/OAuth2/OAuth2.swift
@@ -227,11 +227,11 @@ public class OAuth2: OAuth2Base {
 			}
 		}
 	}
-    
-    #if os(OSX)
-    /// Used to hold a reference to the container (window controller) for embedded authorization on OS X
-    internal var embeddedUI: AnyObject?
-    #endif
+	
+	#if os(OSX)
+	/// Used to hold a reference to the container (window controller) for embedded authorization on OS X
+	internal var embeddedUI: AnyObject?
+	#endif
 	
 	/**
 	If the instance has an accessToken, checks if its expiry time has not yet passed. If we don't have an expiry date we assume the token

--- a/OAuth2/OAuth2AuthConfig.swift
+++ b/OAuth2/OAuth2AuthConfig.swift
@@ -18,6 +18,9 @@
 //  limitations under the License.
 //
 
+#if os(OSX)
+    import Cocoa
+#endif
 
 /**
     Simple struct to hold client-side authorization configuration variables.
@@ -46,7 +49,14 @@ public struct OAuth2AuthConfig
 	/// Whether to use an embedded web view for authorization (true) or the OS browser (false, the default)
 	public var authorizeEmbedded: Bool = false
 	
+    #if os(OSX)
+    /// The block responsible for presenting the web view controller (if not set, a new window will be opened automatically)
+    public var authorizePresentationBlock: ((webViewController: NSViewController) -> Void)?
+    #endif
+    
 	/// Context information for the authorization flow; e.g. the parent view controller to use on iOS.
+    ///
+    /// **Not used for OS X, use `authorizePresentationBlock` instead.**
 	public var authorizeContext: AnyObject? = nil
 	
 	/// UI-specific configuration

--- a/OAuth2/OAuth2AuthConfig.swift
+++ b/OAuth2/OAuth2AuthConfig.swift
@@ -39,6 +39,11 @@ public struct OAuth2AuthConfig
 		/// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
 		public var useSafariView = true
 		
+		#if os(OSX)
+		/// Internally used to store default `NSWindowController` created to contain the web view controller
+		var windowController: NSWindowController?
+		#endif
+		
 		/// Internally used to store the `SFSafariViewControllerDelegate`
 		var safariViewDelegate: AnyObject?
 	}

--- a/OAuth2/OAuth2AuthConfig.swift
+++ b/OAuth2/OAuth2AuthConfig.swift
@@ -49,15 +49,13 @@ public struct OAuth2AuthConfig
 	/// Whether to use an embedded web view for authorization (true) or the OS browser (false, the default)
 	public var authorizeEmbedded: Bool = false
 	
-    #if os(OSX)
-    /// The block responsible for presenting the web view controller (if not set, a new window will be opened automatically)
-    public var authorizePresentationBlock: ((webViewController: NSViewController) -> Void)?
-    #endif
-    
+	#if os(OSX)
+	/// The block responsible for presenting the web view controller (if not set, a new window will be opened automatically)
+	public var authorizeContext: ((webViewController: NSViewController) -> Void)?
+	#else
 	/// Context information for the authorization flow; e.g. the parent view controller to use on iOS.
-    ///
-    /// **Not used for OS X, use `authorizePresentationBlock` instead.**
 	public var authorizeContext: AnyObject? = nil
+	#endif
 	
 	/// UI-specific configuration
 	public var ui = UI()


### PR DESCRIPTION
I have implemented the embedded web view controller for OS X, by default It opens a new window with the embedded `WKWebView`, but I've added an `authorizePresentationBlock` to `OAuth2AuthConfig` which gives the developer a point to customize the presentation.

OS X handles view controllers differently so the way It was implemented for iOS (using `authorizeContext` to present a view controller) would not allow the level of customization I would like to have for my app.

The UI is all in code and I have limited support to 10.11 since I am not able to test on older versions.

I have also updated the OS X demo app to use the embedded authorization method (I tested It with GitHub and Reddit and It worked perfectly).

Important: I have NOT updated the readme to reflect my changes.