### PR TITLE
Exclude OSAuth2Tests in release builds to fix #85

### DIFF
--- a/OAuth2.xcodeproj/xcshareddata/xcschemes/OAuth2OSX.xcscheme
+++ b/OAuth2.xcodeproj/xcshareddata/xcschemes/OAuth2OSX.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">


### PR DESCRIPTION
This allows Carthage to build OAuth2 for Mac