### PR TITLE
No token required (client config)

### DIFF
--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -62,6 +62,9 @@ public class OAuth2ClientConfig {
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if
 	/// "secret_in_body" is `true` and ".ClientSecretBasic" otherwise. Interacts with the `authConfig.secretInBody` client setting.
 	public final var endpointAuthMethod = OAuth2EndpointAuthMethod.None
+    
+    /// No token required, return code
+    public var noTokenRequired: Bool = false
 	
 	
 	/**
@@ -107,6 +110,11 @@ public class OAuth2ClientConfig {
 		if let assume = settings["token_assume_unexpired"] as? Bool {
 			accessTokenAssumeUnexpired = assume
 		}
+        
+        // no token
+        if let noToken = settings["no_token"] as? Bool {
+            noTokenRequired = noToken
+        }
 	}
 	
 	

--- a/Sources/Base/OAuth2CodeGrant.swift
+++ b/Sources/Base/OAuth2CodeGrant.swift
@@ -75,7 +75,11 @@ public class OAuth2CodeGrant: OAuth2 {
 		logger?.debug("OAuth2", msg: "Handling redirect URL \(redirect.description)")
 		do {
 			let code = try validateRedirectURL(redirect)
-			exchangeCodeForToken(code)
+            if clientConfig.noTokenRequired {
+                self.didAuthorize(["code": code] as OAuth2JSON)
+            } else {
+                exchangeCodeForToken(code)
+            }
 		}
 		catch let error {
 			didFail(error)


### PR DESCRIPTION
In some cases we don't need the token because the app doesn't want any information about the user, just authenticate. The backend will login the user and for that it need only the 'code'.