### PR TITLE
Add custom header parameters in core.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,5 @@ Glenn Schmidt, @glennschmidt
 Tomohiro Kumagai, @ez-net
 Tim Sneed, @trsneed
 Vojto Rinik, @vojto
+Vladislav Prusakov, @SpectralDragon
+

--- a/Sources/Base/OAuth2.swift
+++ b/Sources/Base/OAuth2.swift
@@ -109,9 +109,9 @@ public class OAuth2: OAuth2Base {
 	}
     
     /// Contains parameters header.
-    public var headers: OAuth2Headers? {
-        get { return clientConfig.headers }
-        set { clientConfig.headers = newValue }
+    public var authHeaders: OAuth2Headers? {
+        get { return clientConfig.authHeaders }
+        set { clientConfig.authHeaders = newValue }
     }
 	
 	/// Closure called on successful authentication on the main thread.

--- a/Sources/Base/OAuth2.swift
+++ b/Sources/Base/OAuth2.swift
@@ -109,9 +109,9 @@ public class OAuth2: OAuth2Base {
 	}
     
     /// Contains parameters header. Settings key `header_params`
-    public var header: OAuth2StringDict? {
-        get { return clientConfig.headerParams }
-        set { clientConfig.headerParams = newValue }
+    public var headers: OAuth2Headers? {
+        get { return clientConfig.headers }
+        set { clientConfig.headers = newValue }
     }
 	
 	/// Closure called on successful authentication on the main thread.
@@ -169,7 +169,6 @@ public class OAuth2: OAuth2Base {
 		if let ttl = settings["title"] as? String {
 			authConfig.ui.title = ttl
 		}
-
 		super.init(settings: settings)
 	}
 	
@@ -429,7 +428,7 @@ public class OAuth2: OAuth2Base {
 		do {
 			let post = try tokenRequestForTokenRefresh(params: params).asURLRequestFor(self)
 			logger?.debug("OAuth2", msg: "Using refresh token to receive access token from \(post.URL?.description ?? "nil")")
-
+            
 			performRequest(post) { data, status, error in
 				do {
 					guard let data = data else {

--- a/Sources/Base/OAuth2.swift
+++ b/Sources/Base/OAuth2.swift
@@ -107,6 +107,12 @@ public class OAuth2: OAuth2Base {
 		get { return clientConfig.refreshToken }
 		set { clientConfig.refreshToken = newValue }
 	}
+    
+    /// Contains parameters header. Settings key `header_params`
+    public var header: OAuth2StringDict? {
+        get { return clientConfig.headerParams }
+        set { clientConfig.headerParams = newValue }
+    }
 	
 	/// Closure called on successful authentication on the main thread.
 	public final var onAuthorize: ((parameters: OAuth2JSON) -> Void)?
@@ -163,6 +169,7 @@ public class OAuth2: OAuth2Base {
 		if let ttl = settings["title"] as? String {
 			authConfig.ui.title = ttl
 		}
+
 		super.init(settings: settings)
 	}
 	
@@ -422,7 +429,7 @@ public class OAuth2: OAuth2Base {
 		do {
 			let post = try tokenRequestForTokenRefresh(params: params).asURLRequestFor(self)
 			logger?.debug("OAuth2", msg: "Using refresh token to receive access token from \(post.URL?.description ?? "nil")")
-			
+
 			performRequest(post) { data, status, error in
 				do {
 					guard let data = data else {

--- a/Sources/Base/OAuth2.swift
+++ b/Sources/Base/OAuth2.swift
@@ -50,7 +50,7 @@ public class OAuth2: OAuth2Base {
 	
 	/// The client secret, usually only needed for code grant.
 	public final var clientSecret: String? {
-		get { return clientConfig.clientSecret }
+        get { return clientConfig.clientSecret }
 		set { clientConfig.clientSecret = newValue }
 	}
 	
@@ -108,7 +108,7 @@ public class OAuth2: OAuth2Base {
 		set { clientConfig.refreshToken = newValue }
 	}
     
-    /// Contains parameters header. Settings key `header_params`
+    /// Contains parameters header.
     public var headers: OAuth2Headers? {
         get { return clientConfig.headers }
         set { clientConfig.headers = newValue }

--- a/Sources/Base/OAuth2.swift
+++ b/Sources/Base/OAuth2.swift
@@ -50,7 +50,7 @@ public class OAuth2: OAuth2Base {
 	
 	/// The client secret, usually only needed for code grant.
 	public final var clientSecret: String? {
-        get { return clientConfig.clientSecret }
+		get { return clientConfig.clientSecret }
 		set { clientConfig.clientSecret = newValue }
 	}
 	
@@ -107,12 +107,12 @@ public class OAuth2: OAuth2Base {
 		get { return clientConfig.refreshToken }
 		set { clientConfig.refreshToken = newValue }
 	}
-    
-    /// Contains parameters header.
-    public var authHeaders: OAuth2Headers? {
-        get { return clientConfig.authHeaders }
-        set { clientConfig.authHeaders = newValue }
-    }
+	
+	/// Contains parameters header.
+	public var authHeaders: OAuth2Headers? {
+		get { return clientConfig.authHeaders }
+		set { clientConfig.authHeaders = newValue }
+	}
 	
 	/// Closure called on successful authentication on the main thread.
 	public final var onAuthorize: ((parameters: OAuth2JSON) -> Void)?
@@ -428,7 +428,7 @@ public class OAuth2: OAuth2Base {
 		do {
 			let post = try tokenRequestForTokenRefresh(params: params).asURLRequestFor(self)
 			logger?.debug("OAuth2", msg: "Using refresh token to receive access token from \(post.URL?.description ?? "nil")")
-            
+			
 			performRequest(post) { data, status, error in
 				do {
 					guard let data = data else {

--- a/Sources/Base/OAuth2AuthRequest.swift
+++ b/Sources/Base/OAuth2AuthRequest.swift
@@ -136,12 +136,11 @@ public class OAuth2AuthRequest {
 		req.setValue(contentType.rawValue, forHTTPHeaderField: "Content-Type")
 		req.setValue("application/json", forHTTPHeaderField: "Accept")
         
-        if let headerParams = oauth2.header where !headerParams.isEmpty {
+        if let headerParams = oauth2.headers where !headerParams.isEmpty {
             for (key, value) in headerParams {
                 req.setValue(value, forHTTPHeaderField: key)
             }
         }
-		
 		// handle client secret if there is one
 		if let clientId = oauth2.clientConfig.clientId where !clientId.isEmpty, let secret = oauth2.clientConfig.clientSecret {
 			

--- a/Sources/Base/OAuth2AuthRequest.swift
+++ b/Sources/Base/OAuth2AuthRequest.swift
@@ -135,6 +135,12 @@ public class OAuth2AuthRequest {
 		req.HTTPMethod = method.rawValue
 		req.setValue(contentType.rawValue, forHTTPHeaderField: "Content-Type")
 		req.setValue("application/json", forHTTPHeaderField: "Accept")
+        
+        if let headerParams = oauth2.header where !headerParams.isEmpty {
+            for (key, value) in headerParams {
+                req.setValue(key, forHTTPHeaderField: value)
+            }
+        }
 		
 		// handle client secret if there is one
 		if let clientId = oauth2.clientConfig.clientId where !clientId.isEmpty, let secret = oauth2.clientConfig.clientSecret {

--- a/Sources/Base/OAuth2AuthRequest.swift
+++ b/Sources/Base/OAuth2AuthRequest.swift
@@ -138,7 +138,7 @@ public class OAuth2AuthRequest {
         
         if let headerParams = oauth2.header where !headerParams.isEmpty {
             for (key, value) in headerParams {
-                req.setValue(key, forHTTPHeaderField: value)
+                req.setValue(value, forHTTPHeaderField: key)
             }
         }
 		

--- a/Sources/Base/OAuth2AuthRequest.swift
+++ b/Sources/Base/OAuth2AuthRequest.swift
@@ -136,7 +136,7 @@ public class OAuth2AuthRequest {
 		req.setValue(contentType.rawValue, forHTTPHeaderField: "Content-Type")
 		req.setValue("application/json", forHTTPHeaderField: "Accept")
         
-        if let headerParams = oauth2.headers where !headerParams.isEmpty {
+        if let headerParams = oauth2.authHeaders where !headerParams.isEmpty {
             for (key, value) in headerParams {
                 req.setValue(value, forHTTPHeaderField: key)
             }

--- a/Sources/Base/OAuth2AuthRequest.swift
+++ b/Sources/Base/OAuth2AuthRequest.swift
@@ -136,11 +136,11 @@ public class OAuth2AuthRequest {
 		req.setValue(contentType.rawValue, forHTTPHeaderField: "Content-Type")
 		req.setValue("application/json", forHTTPHeaderField: "Accept")
         
-        if let headerParams = oauth2.authHeaders where !headerParams.isEmpty {
-            for (key, value) in headerParams {
-                req.setValue(value, forHTTPHeaderField: key)
-            }
-        }
+		if let headerParams = oauth2.authHeaders where !headerParams.isEmpty {
+			for (key, value) in headerParams {
+				req.setValue(value, forHTTPHeaderField: key)
+			}
+		}
 		// handle client secret if there is one
 		if let clientId = oauth2.clientConfig.clientId where !clientId.isEmpty, let secret = oauth2.clientConfig.clientSecret {
 			

--- a/Sources/Base/OAuth2Base.swift
+++ b/Sources/Base/OAuth2Base.swift
@@ -27,6 +27,9 @@ public typealias OAuth2JSON = [String: AnyObject]
 /// Typealias to work with dictionaries full of strings.
 public typealias OAuth2StringDict = [String: String]
 
+/// Typealias to work with headers
+public typealias OAuth2Headers = [String: String]
+
 
 /**
 Abstract base class for OAuth2 authorization as well as client registration classes.

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -59,8 +59,8 @@ public class OAuth2ClientConfig {
 	/// The URL to register a client against.
 	public final var registrationURL: NSURL?
     
-    /// Contains parameters header.
-    public var headerParams: OAuth2StringDict?
+    /// Contains parameters headers.
+    public var headers: OAuth2Headers?
 	
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if
 	/// "secret_in_body" is `true` and ".ClientSecretBasic" otherwise. Interacts with the `authConfig.secretInBody` client setting.
@@ -110,9 +110,8 @@ public class OAuth2ClientConfig {
 		if let assume = settings["token_assume_unexpired"] as? Bool {
 			accessTokenAssumeUnexpired = assume
 		}
-        
-        if let params = settings["header_params"] as? OAuth2StringDict {
-            headerParams = params
+        if let params = settings["header_params"] as? OAuth2Headers {
+            headers = params
         }
 	}
 	

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -60,7 +60,7 @@ public class OAuth2ClientConfig {
 	public final var registrationURL: NSURL?
     
     /// Contains parameters headers.
-    public var headers: OAuth2Headers?
+    public var authHeaders: OAuth2Headers?
 	
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if
 	/// "secret_in_body" is `true` and ".ClientSecretBasic" otherwise. Interacts with the `authConfig.secretInBody` client setting.
@@ -110,8 +110,8 @@ public class OAuth2ClientConfig {
 		if let assume = settings["token_assume_unexpired"] as? Bool {
 			accessTokenAssumeUnexpired = assume
 		}
-        if let params = settings["headers"] as? OAuth2Headers {
-            headers = params
+        if let headers = settings["headers"] as? OAuth2Headers {
+            authHeaders = headers
         }
 	}
 	

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -110,7 +110,7 @@ public class OAuth2ClientConfig {
 		if let assume = settings["token_assume_unexpired"] as? Bool {
 			accessTokenAssumeUnexpired = assume
 		}
-        if let params = settings["header_params"] as? OAuth2Headers {
+        if let params = settings["headers"] as? OAuth2Headers {
             headers = params
         }
 	}

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -60,7 +60,7 @@ public class OAuth2ClientConfig {
 	public final var registrationURL: NSURL?
     
     /// Contains parameters headers.
-    public var authHeaders: OAuth2Headers?
+	public var authHeaders: OAuth2Headers?
 	
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if
 	/// "secret_in_body" is `true` and ".ClientSecretBasic" otherwise. Interacts with the `authConfig.secretInBody` client setting.
@@ -110,9 +110,9 @@ public class OAuth2ClientConfig {
 		if let assume = settings["token_assume_unexpired"] as? Bool {
 			accessTokenAssumeUnexpired = assume
 		}
-        if let headers = settings["headers"] as? OAuth2Headers {
-            authHeaders = headers
-        }
+		if let headers = settings["headers"] as? OAuth2Headers {
+			authHeaders = headers
+		}
 	}
 	
 	

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -59,7 +59,7 @@ public class OAuth2ClientConfig {
 	/// The URL to register a client against.
 	public final var registrationURL: NSURL?
     
-    /// Contains parameters headers.
+	/// Contains parameters headers.
 	public var authHeaders: OAuth2Headers?
 	
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -58,6 +58,9 @@ public class OAuth2ClientConfig {
 	
 	/// The URL to register a client against.
 	public final var registrationURL: NSURL?
+    
+    /// Contains parameters header.
+    public var headerParams: OAuth2StringDict?
 	
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if
 	/// "secret_in_body" is `true` and ".ClientSecretBasic" otherwise. Interacts with the `authConfig.secretInBody` client setting.
@@ -107,6 +110,10 @@ public class OAuth2ClientConfig {
 		if let assume = settings["token_assume_unexpired"] as? Bool {
 			accessTokenAssumeUnexpired = assume
 		}
+        
+        if let params = settings["header_params"] as? OAuth2StringDict {
+            headerParams = params
+        }
 	}
 	
 	


### PR DESCRIPTION
Now there is the possibility to set custom headers using the key `header_params`. I refused to subclass and now all the action takes place in the nucleus `OAuth2AuthRequest`. Thank you in advance :)

Excuse me for my broken English :'D
