### PR TITLE
Add workaround for issue in Safari

### DIFF
--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -68,7 +68,19 @@ open class OAuth2ClientConfig {
 	
 	/// Custom request parameters to be added during authorization.
 	open var authParameters: OAuth2StringDict?
-	
+
+	/// There's an issue with authenticating through 'system browser', where safari says:
+	/// "Safari cannot open the page because the address is invalid." if you first selects 'Cancel'
+	/// when asked to switch back to "your" app, and then you try authenticating again.
+	/// To get rid of it you must restart Safari.
+	///
+	/// Read more about it here:
+	/// http://stackoverflow.com/questions/27739442/ios-safari-does-not-recognize-url-schemes-after-user-cancels
+	/// https://community.fitbit.com/t5/Web-API/oAuth2-authentication-page-gives-me-a-quot-Cannot-Open-Page-quot-error/td-p/1150391
+	///
+	/// Toggling `safariCancelWorkaround` to true will send an extra get-paramter to make the url unique,
+	/// thus it will ask again for the new url.
+	open var safariCancelWorkaround = false	
 	
 	/**
 	Initializer to initialize properties from a settings dictionary.

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -282,6 +282,9 @@ open class OAuth2: OAuth2Base {
 		req.params["redirect_uri"] = redirect
 		req.params["client_id"] = clientId
 		req.params["state"] = context.state
+		if clientConfig.safariCancelWorkaround {
+			req.params["swa"] = "\(Date.timeIntervalSinceReferenceDate)" // Safari issue workaround
+		}
 		if let scope = scope ?? clientConfig.scope {
 			req.params["scope"] = scope
 		}


### PR DESCRIPTION
There's an issue with Safari, references in some websites, where you can't open
the url again if you press 'Cancel' once when asking to go back to original
app. For the user to workaround this issue it has to restart Safari, which is
not really nice. This fix instead gives the option to append a parameter to
the url, which will make it unique, thus the browser till prompt the user again
next time the app authenticates.

https://community.fitbit.com/t5/Web-API/oAuth2-authentication-page-gives-me-a-quot-Cannot-Open-Page-quot-error/td-p/1150391
http://stackoverflow.com/questions/27739442/ios-safari-does-not-recognize-url-schemes-after-user-cancels