### PR TITLE
Add OAuth2CodeGrantAzure to authenticate against Microsoft Azure

### DIFF
--- a/OAuth2.xcodeproj/project.pbxproj
+++ b/OAuth2.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C2F5E5B1DE2DB8500F621E0 /* OAuth2CodeGrantAzure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2F5E5A1DE2DB8500F621E0 /* OAuth2CodeGrantAzure.swift */; };
 		6598544E1C5B3C9500237D39 /* OAuth2Authorizer+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6598543F1C5B3B4000237D39 /* OAuth2Authorizer+tvOS.swift */; };
 		6598544F1C5B3C9C00237D39 /* OAuth2Base.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDB8640193FAB9200C4EEA1 /* OAuth2Base.swift */; };
 		659854501C5B3C9C00237D39 /* OAuth2Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF47D2A1B1E3FDD0057D838 /* OAuth2Requestable.swift */; };
@@ -154,6 +155,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0C2F5E5A1DE2DB8500F621E0 /* OAuth2CodeGrantAzure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2CodeGrantAzure.swift; sourceTree = "<group>"; };
 		6598543F1C5B3B4000237D39 /* OAuth2Authorizer+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "OAuth2Authorizer+tvOS.swift"; path = "Sources/tvOS/OAuth2Authorizer+tvOS.swift"; sourceTree = SOURCE_ROOT; };
 		659854461C5B3BEA00237D39 /* OAuth2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuth2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65EC05DF1C9050CB00DE9186 /* OAuth2KeychainAccount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2KeychainAccount.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 				EE29836F1D40B83600933CDD /* OAuth2.swift */,
 				EE3174EB1945E83100210E62 /* OAuth2ImplicitGrant.swift */,
 				EE44F691194F2C7D0094AB8B /* OAuth2CodeGrant.swift */,
+				0C2F5E5A1DE2DB8500F621E0 /* OAuth2CodeGrantAzure.swift */,
 				EEACE1DE1A7E8FC1009BF3A7 /* OAuth2CodeGrantFacebook.swift */,
 				EEC6D57B1C2837EA00FA9B1C /* OAuth2CodeGrantLinkedIn.swift */,
 				EE1391D91AC5B41A002C7B18 /* OAuth2CodeGrantBasicAuth.swift */,
@@ -698,6 +701,7 @@
 				EEC7A8D81AE4851E008C30E7 /* Keychain.swift in Sources */,
 				EEAEF10B1CDBCF28001A1C6F /* OAuth2Logger.swift in Sources */,
 				65EC05E01C9050CB00DE9186 /* OAuth2KeychainAccount.swift in Sources */,
+				0C2F5E5B1DE2DB8500F621E0 /* OAuth2CodeGrantAzure.swift in Sources */,
 				DD0CCBAD1C4DC83A0044C4E3 /* OAuth2WebViewController.swift in Sources */,
 				EE9EBF1B1D775F74003263FC /* OAuth2Securable.swift in Sources */,
 				EE79F65A1BFAA36900746243 /* OAuth2Error.swift in Sources */,

--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -45,7 +45,10 @@ public struct OAuth2AuthConfig {
 	
 	/// Whether to automatically dismiss the auto-presented authorization screen.
 	public var authorizeEmbeddedAutoDismiss = true
-	
+
+	/// Add custom parameters to the request
+	public var customParameters: [String: String]? = nil
+
 	/// Context information for the authorization flow:
 	/// - iOS:   The parent view controller to present from
 	/// - macOS: An NSWindow from which to present a modal sheet _or_ `nil` to present in a new window

--- a/Sources/Base/OAuth2AuthRequest.swift
+++ b/Sources/Base/OAuth2AuthRequest.swift
@@ -220,7 +220,11 @@ open class OAuth2AuthRequest {
 				req.setValue(val, forHTTPHeaderField: key)
 			}
 		}
-		
+		if let customParameters = oauth2.authConfig.customParameters {
+			for (k, v) in customParameters {
+				finalParams[k] = v
+			}
+		}
 		// add a body to POST requests
 		if .POST == method && finalParams.count > 0 {
 			req.httpBody = try finalParams.utf8EncodedData()

--- a/Sources/Flows/OAuth2CodeGrantAzure.swift
+++ b/Sources/Flows/OAuth2CodeGrantAzure.swift
@@ -1,0 +1,40 @@
+//
+//  OAuth2CodeGrantAzure.swift
+//  OAuth2
+//
+//  Created by Pascal Pfiffner on 2/1/15.
+//  Copyright 2016 David Everlöf
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+#if !NO_MODULE_IMPORT
+    import Base
+#endif
+
+
+/**
+ Azure requires a `resource`, hence our `init` requires it as well
+ */
+public class OAuth2CodeGrantAzure: OAuth2CodeGrant {
+
+	public init(settings: OAuth2JSON, resource: String) {
+		super.init(settings: settings)
+		authConfig.secretInBody = true
+		authConfig.customParameters = [
+			"resource": resource
+		]
+	}
+}
+

--- a/Tests/FlowTests/OAuth2CodeGrantTests.swift
+++ b/Tests/FlowTests/OAuth2CodeGrantTests.swift
@@ -253,6 +253,26 @@ class OAuth2CodeGrantTests: XCTestCase {
 		XCTAssertEqual(query2["redirect_uri"]!, "oauth2://callback", "Expecting correct `redirect_uri`")
 		XCTAssertNil(query2["state"], "`state` must be empty")
 	}
+
+	func testCustomAuthParameters() {
+		let oauth = OAuth2CodeGrant(settings: baseSettings)
+		oauth.redirect = "oauth2://callback"
+		oauth.context.redirectURL = "oauth2://callback"
+
+		// not in body
+		let req = try! oauth.accessTokenRequest(with: "pp").asURLRequest(for: oauth)
+		let body = String(data: req.httpBody!, encoding: String.Encoding.utf8)
+		let query = OAuth2CodeGrant.params(fromQuery: body!)
+		XCTAssertNil(query["foo"], "`foo` should be nil")
+
+		oauth.authConfig.customParameters = [ "foo": "bar" ]
+
+		// in body
+		let req2 = try! oauth.accessTokenRequest(with: "pp").asURLRequest(for: oauth)
+		let body2 = String(data: req2.httpBody!, encoding: String.Encoding.utf8)
+		let query2 = OAuth2CodeGrant.params(fromQuery: body2!)
+		XCTAssertEqual(query2["foo"]!, "bar", "Expecting key `foo` to be `bar`")
+    }
 	
 	func testTokenRequestAgainstAuthURL() {
 		


### PR DESCRIPTION
OAuth2CodeGrantAzure requires the client to indicate which resource are requested.
This required the addition of `customParameters` in `OAuth2AuthConfig`
which adds custom parameter to the body of the request