### PR TITLE
Fix normalizeRefreshTokenResponseKeys(dict:) not being called

### DIFF
--- a/Sources/Base/OAuth2Base.swift
+++ b/Sources/Base/OAuth2Base.swift
@@ -412,7 +412,7 @@ open class OAuth2Base: OAuth2Securable {
 		try assureCorrectBearerType(dict)
 		try assureRefreshTokenParamsAreValid(dict)
 		
-		clientConfig.updateFromResponse(dict)
+		clientConfig.updateFromResponse(normalizeRefreshTokenResponseKeys(dict))
 		return dict
 	}
 	


### PR DESCRIPTION
…from parseRefreshTokenResponse(dict:)

I couldn't find anywhere that normalizeRefreshTokenResponseKeys(dict:) was called from actually.