### PR TITLE
Making macOS web view controller public

### DIFF
--- a/Sources/macOS/OAuth2WebViewController.swift
+++ b/Sources/macOS/OAuth2WebViewController.swift
@@ -78,7 +78,7 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 	public var onWillCancel: ((Void) -> Void)?
 	
 	/// Our web view; implicitly unwrapped so do not attempt to use it unless isViewLoaded() returns true.
-	var webView: WKWebView!
+	public var webView: WKWebView!
 	
 	private var progressIndicator: NSProgressIndicator!
 	private var loadingView: NSView {

--- a/Sources/macOS/OAuth2WebViewController.swift
+++ b/Sources/macOS/OAuth2WebViewController.swift
@@ -32,7 +32,7 @@ A view controller that allows you to display the login/authorization screen.
 @available(macOS 10.10, *)
 public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NSWindowDelegate {
 	
-	init() {
+	public init() {
 		super.init(nibName: nil, bundle: nil)!
 	}
 	

--- a/Sources/macOS/OAuth2WebViewController.swift
+++ b/Sources/macOS/OAuth2WebViewController.swift
@@ -78,7 +78,7 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 	public var onWillCancel: ((Void) -> Void)?
 	
 	/// Our web view; implicitly unwrapped so do not attempt to use it unless isViewLoaded() returns true.
-	public var webView: WKWebView!
+	var webView: WKWebView!
 	
 	private var progressIndicator: NSProgressIndicator!
 	private var loadingView: NSView {

--- a/Sources/macOS/OAuth2WebViewController.swift
+++ b/Sources/macOS/OAuth2WebViewController.swift
@@ -52,7 +52,7 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 	}
 	
 	/// The URL string to intercept and respond to.
-	var interceptURLString: String? {
+	public var interceptURLString: String? {
 		didSet(oldURL) {
 			if nil != interceptURLString {
 				if let url = URL(string: interceptURLString!) {
@@ -72,10 +72,10 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 	
 	/// Closure called when the web view gets asked to load the redirect URL, specified in `interceptURLString`. Return a Bool indicating
 	/// that you've intercepted the URL.
-	var onIntercept: ((URL) -> Bool)?
+	public var onIntercept: ((URL) -> Bool)?
 	
 	/// Called when the web view is about to be dismissed manually.
-	var onWillCancel: ((Void) -> Void)?
+	public var onWillCancel: ((Void) -> Void)?
 	
 	/// Our web view; implicitly unwrapped so do not attempt to use it unless isViewLoaded() returns true.
 	var webView: WKWebView!


### PR DESCRIPTION
I'm trying to use web view controller from custom subclass of AuthorizerUI. So I need these things public:

- initializer
- `interceptURLString`
- `onIntercept`
- `onWillCancel`

Feel free to close if the use case doesn't make sense. I'm doing too much customisation.

Overall goal is to show the view controller in my own window which is part of wizard-like dialog.