### PR TITLE
Remove `@nonobjc` attribute

### DIFF
--- a/Sources/macOS/OAuth2WebViewController.swift
+++ b/Sources/macOS/OAuth2WebViewController.swift
@@ -201,7 +201,6 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 	
 	// MARK: - Web View Delegate
 	
-	@nonobjc
 	public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
 		let request = navigationAction.request
 		


### PR DESCRIPTION
On macOS, the `@nonobjc` attribute on the following function in `OAuth2WebViewController` prevents it from being called:

```
public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void)
```

As I understand it, the `@nonobjc` attribute prevents this function from being bridged to the Obj-C version. Removing `@nonobjc` results in the function being called as expected (when WebView navigation is about to occur).


My environment:
```
macOS 10.11.6
Xcode 8.2.1 (8C1002)
Swift 3.0
```

OAuth flow using:
```
OAuth2CodeGrant with redirect_uris
authorizeEmbedded = true
```