### PR TITLE
Add config to hide Cancel button on Embedded Authorization WebView

### DIFF
--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -32,6 +32,9 @@ public struct OAuth2AuthConfig {
 		
 		/// By assigning your own UIBarButtonItem (!) you can override the back button that is shown in the iOS embedded web view (does NOT apply to `SFSafariViewController`).
 		public var backButton: AnyObject? = nil
+
+        /// If true it makes the login cancellable, otherwise the cancel button is not shown in the embedded web view.
+        public var showCancelButton = true
 		
 		/// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
 		public var useSafariView = true

--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -33,7 +33,7 @@ public struct OAuth2AuthConfig {
 		/// By assigning your own UIBarButtonItem (!) you can override the back button that is shown in the iOS embedded web view (does NOT apply to `SFSafariViewController`).
 		public var backButton: AnyObject? = nil
 
-        /// If true it makes the login cancellable, otherwise the cancel button is not shown in the embedded web view.
+		/// If true it makes the login cancellable, otherwise the cancel button is not shown in the embedded web view.
 		public var showCancelButton = true
 		
 		/// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.

--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -34,7 +34,7 @@ public struct OAuth2AuthConfig {
 		public var backButton: AnyObject? = nil
 
         /// If true it makes the login cancellable, otherwise the cancel button is not shown in the embedded web view.
-        public var showCancelButton = true
+		public var showCancelButton = true
 		
 		/// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
 		public var useSafariView = true

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -155,6 +155,7 @@ public final class OAuth2Authorizer: OAuth2AuthorizerUI {
 		let web = OAuth2WebViewController()
 		web.title = oauth2.authConfig.ui.title
 		web.backButton = oauth2.authConfig.ui.backButton as? UIBarButtonItem
+        web.showCancelButton = oauth2.authConfig.ui.showCancelButton
 		web.startURL = url
 		web.interceptURLString = intercept
 		web.onIntercept = { url in

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -155,7 +155,7 @@ public final class OAuth2Authorizer: OAuth2AuthorizerUI {
 		let web = OAuth2WebViewController()
 		web.title = oauth2.authConfig.ui.title
 		web.backButton = oauth2.authConfig.ui.backButton as? UIBarButtonItem
-        web.showCancelButton = oauth2.authConfig.ui.showCancelButton
+		web.showCancelButton = oauth2.authConfig.ui.showCancelButton
 		web.startURL = url
 		web.interceptURLString = intercept
 		web.onIntercept = { url in

--- a/Sources/iOS/OAuth2WebViewController.swift
+++ b/Sources/iOS/OAuth2WebViewController.swift
@@ -77,7 +77,8 @@ open class OAuth2WebViewController: UIViewController, UIWebViewDelegate {
 			}
 		}
 	}
-	
+
+    var showCancelButton: Bool = true
 	var cancelButton: UIBarButtonItem?
 	
 	/// Our web view.
@@ -104,10 +105,12 @@ open class OAuth2WebViewController: UIViewController, UIWebViewDelegate {
 		
 		super.loadView()
 		view.backgroundColor = UIColor.white
-		
-		cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(OAuth2WebViewController.cancel(_:)))
-		navigationItem.rightBarButtonItem = cancelButton
-		
+
+        if showCancelButton == true {
+            cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(OAuth2WebViewController.cancel(_:)))
+            navigationItem.rightBarButtonItem = cancelButton
+        }
+
 		// create a web view
 		let web = UIWebView()
 		web.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/iOS/OAuth2WebViewController.swift
+++ b/Sources/iOS/OAuth2WebViewController.swift
@@ -106,7 +106,7 @@ open class OAuth2WebViewController: UIViewController, UIWebViewDelegate {
 		super.loadView()
 		view.backgroundColor = UIColor.white
 
-		if showCancelButton == true {
+		if showCancelButton {
 			cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(OAuth2WebViewController.cancel(_:)))
 			navigationItem.rightBarButtonItem = cancelButton
 		}

--- a/Sources/iOS/OAuth2WebViewController.swift
+++ b/Sources/iOS/OAuth2WebViewController.swift
@@ -78,7 +78,7 @@ open class OAuth2WebViewController: UIViewController, UIWebViewDelegate {
 		}
 	}
 
-    var showCancelButton: Bool = true
+	var showCancelButton: Bool = true
 	var cancelButton: UIBarButtonItem?
 	
 	/// Our web view.
@@ -106,10 +106,10 @@ open class OAuth2WebViewController: UIViewController, UIWebViewDelegate {
 		super.loadView()
 		view.backgroundColor = UIColor.white
 
-        if showCancelButton == true {
-            cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(OAuth2WebViewController.cancel(_:)))
-            navigationItem.rightBarButtonItem = cancelButton
-        }
+		if showCancelButton == true {
+			cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(OAuth2WebViewController.cancel(_:)))
+			navigationItem.rightBarButtonItem = cancelButton
+		}
 
 		// create a web view
 		let web = UIWebView()


### PR DESCRIPTION
Sometimes we need to make the login mandatory.
We need to avoid cancelling the login dialog.
Added a parameter on OAuth2AuthConfig to decide when the Cancel button should be visible.
(by default is visible)