### PR TITLE
Add config to set Modal Presentation Style for embedded authorization

### DIFF
--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -35,6 +35,10 @@ public struct OAuth2AuthConfig {
 		
 		/// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
 		public var useSafariView = true
+
+        /// By assigning your own UIModalPresentationStyle (!) you can configure how the embedded authorisation is presented.
+        public var modalPresentationStyle = 0
+
 	}
 	
 	/// Whether to use an embedded web view for authorization (true) or the OS browser (false, the default).

--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -36,8 +36,8 @@ public struct OAuth2AuthConfig {
 		/// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
 		public var useSafariView = true
 
-        /// By assigning your own UIModalPresentationStyle (!) you can configure how the embedded authorisation is presented.
-        public var modalPresentationStyle = 0
+		/// By assigning your own UIModalPresentationStyle (!) you can configure how the embedded authorisation is presented.
+		public var modalPresentationStyle = 0
 
 	}
 	

--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -22,6 +22,10 @@
 /**
 Simple struct to hold settings describing how authorization appears to the user.
 */
+#if os(iOS)
+	import UIKit
+#endif
+
 public struct OAuth2AuthConfig {
 	
 	/// Sub-stuct holding configuration relevant to UI presentation.
@@ -37,7 +41,9 @@ public struct OAuth2AuthConfig {
 		public var useSafariView = true
 
 		/// By assigning your own UIModalPresentationStyle (!) you can configure how the embedded authorisation is presented.
-		public var modalPresentationStyle = 0
+		#if os(iOS)
+		public var modalPresentationStyle = UIModalPresentationStyle.fullScreen
+		#endif
 	}
 	
 	/// Whether to use an embedded web view for authorization (true) or the OS browser (false, the default).

--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -38,7 +38,6 @@ public struct OAuth2AuthConfig {
 
 		/// By assigning your own UIModalPresentationStyle (!) you can configure how the embedded authorisation is presented.
 		public var modalPresentationStyle = 0
-
 	}
 	
 	/// Whether to use an embedded web view for authorization (true) or the OS browser (false, the default).

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -174,11 +174,7 @@ public final class OAuth2Authorizer: OAuth2AuthorizerUI {
 		}
 		
 		let navi = UINavigationController(rootViewController: web)
-
-		if let modalStyle = UIModalPresentationStyle(rawValue: self.oauth2.authConfig.ui.modalPresentationStyle) {
-			navi.modalPresentationStyle = modalStyle
-		}
-
+		navi.modalPresentationStyle = self.oauth2.authConfig.ui.modalPresentationStyle
 		from.present(navi, animated: true)
 		
 		return web

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -174,6 +174,12 @@ public final class OAuth2Authorizer: OAuth2AuthorizerUI {
 		}
 		
 		let navi = UINavigationController(rootViewController: web)
+
+        if let modalStyle = UIModalPresentationStyle(rawValue: self.oauth2.authConfig.ui.modalPresentationStyle)
+        {
+            navi.modalPresentationStyle = modalStyle
+        }
+
 		from.present(navi, animated: true)
 		
 		return web

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -175,10 +175,10 @@ public final class OAuth2Authorizer: OAuth2AuthorizerUI {
 		
 		let navi = UINavigationController(rootViewController: web)
 
-        if let modalStyle = UIModalPresentationStyle(rawValue: self.oauth2.authConfig.ui.modalPresentationStyle)
-        {
-            navi.modalPresentationStyle = modalStyle
-        }
+		if let modalStyle = UIModalPresentationStyle(rawValue: self.oauth2.authConfig.ui.modalPresentationStyle)
+		{
+			navi.modalPresentationStyle = modalStyle
+		}
 
 		from.present(navi, animated: true)
 		

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -175,8 +175,7 @@ public final class OAuth2Authorizer: OAuth2AuthorizerUI {
 		
 		let navi = UINavigationController(rootViewController: web)
 
-		if let modalStyle = UIModalPresentationStyle(rawValue: self.oauth2.authConfig.ui.modalPresentationStyle)
-		{
+		if let modalStyle = UIModalPresentationStyle(rawValue: self.oauth2.authConfig.ui.modalPresentationStyle) {
 			navi.modalPresentationStyle = modalStyle
 		}
 


### PR DESCRIPTION
Could be useful to show the embedded authorization in one of the available UIModalPresentationStyle.
Added a parameter in OAuth2AuthConfig to set the UIModalPresentationStyle used to present the embedded authorization webview