### PR TITLE
Fixed wrong property access control in the Password grant flow

### DIFF
--- a/Sources/Flows/OAuth2PasswordGrant.swift
+++ b/Sources/Flows/OAuth2PasswordGrant.swift
@@ -67,7 +67,7 @@ open class OAuth2PasswordGrant: OAuth2 {
 	open var password: String?
 	
 	/// Properties used to handle the native controller.
-	lazy var customAuthorizer: OAuth2CustomAuthorizerUI = OAuth2CustomAuthorizer()
+	open lazy var customAuthorizer: OAuth2CustomAuthorizerUI = OAuth2CustomAuthorizer()
 	
 	/**
 	If credentials are unknown when trying to authorize, the delegate will be asked a login controller to present.


### PR DESCRIPTION
In the Password grant flow, the customAuthorizer is now `open` instead of `internal` so that we can now provide our own implementation. It was supposed to already be the case but it seems like forgot it :p