### PR TITLE
Expiration check is now optional

### DIFF
--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -55,6 +55,9 @@ public struct OAuth2AuthConfig {
 		#endif
 	}
 	
+	/// Whether to always refresh the token or to only do it when it's expired.
+	public var refreshTokenWhenUnexpired = false
+	
 	/// Whether to use an embedded web view for authorization (true) or the OS browser (false, the default).
 	public var authorizeEmbedded = false
 	

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -168,7 +168,7 @@ open class OAuth2: OAuth2Base {
 	/**
 	Attempts to receive a new access token by:
 	
-	1. checking if there still is an unexpired token
+	1. checking if there still is an unexpired token (if configured like so)
 	2. attempting to use a refresh token
 	
 	Indicates, in the callback, whether the client has been able to obtain an access token that is likely to still work (but there is no
@@ -179,7 +179,7 @@ open class OAuth2: OAuth2Base {
 	                      access token is present
 	*/
 	open func tryToObtainAccessTokenIfNeeded(params: OAuth2StringDict? = nil, callback: @escaping ((OAuth2JSON?) -> Void)) {
-		if hasUnexpiredAccessToken() {
+		if !authConfig.refreshTokenWhenUnexpired && hasUnexpiredAccessToken() {
 			logger?.debug("OAuth2", msg: "Have an apparently unexpired access token")
 			callback(OAuth2JSON())
 		}

--- a/Sources/Flows/OAuth2PasswordGrant.swift
+++ b/Sources/Flows/OAuth2PasswordGrant.swift
@@ -67,7 +67,7 @@ open class OAuth2PasswordGrant: OAuth2 {
 	open var password: String?
 	
 	/// Properties used to handle the native controller.
-	lazy var customAuthorizer: OAuth2CustomAuthorizerUI = OAuth2CustomAuthorizer()
+	open lazy var customAuthorizer: OAuth2CustomAuthorizerUI = OAuth2CustomAuthorizer()
 	
 	/**
 	If credentials are unknown when trying to authorize, the delegate will be asked a login controller to present.


### PR DESCRIPTION
When trying to authenticate, the token is only refreshed when it has expired locally. But if the server expires the token early, it would cause the workflow to be stuck in an infinite loop until we call 'forgeTokens':
- `attemptToAuthorize` is called for some reason
- `tryToObtainAccessTokenIfNeeded` will return the old token without refreshing it
- network request will be performed with the old token
- server will return 401 errors
- ``attemptToAuthorize` is called again
- repeat endlessly

By adding the `refreshTokenWhenUnexpired` in the authConfig, we can now bypass the expiration date check and avoid those edge cases.

Another workaround would be to always call `forgetTokens` when getting a 401 error but this will lead to showing the auth views every time wheareas the `refreshTokenWhenUnexpired` solution make it painless for the user.