### PR TITLE
Added a guard check to request the shared UIApplication instance usin…

### DIFF
--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -55,9 +55,10 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	*/
 	public func openAuthorizeURLInBrowser(_ url: URL) throws {
 		
-		// By asking for the shared instance method by using the "value for key" method on UIApplication, we are able to bypass the Swfit compilation 
-		// restriction that blocks the library from being compiled for an extension when directly referencing it. We do it as an optional so in the 
-		// advent of this method being called, like in an extension, we handle it as though its not supported.
+		// By asking for the shared instance method by using the "value for key" method on UIApplication, we are able to
+		// bypass the Swfit compilation restriction that blocks the library from being compiled for an extension when 
+		// directly referencing it. We do it as an optional so in the advent of this method being called, like in an 
+		// extension, we handle it as though its not supported.
 		guard let application = UIApplication.value(forKey: "sharedApplication") as? UIApplication else {
 			throw OAuth2Error.unableToOpenAuthorizeURL
 		}

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -54,15 +54,15 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	- throws: UnableToOpenAuthorizeURL on failure
 	*/
 	public func openAuthorizeURLInBrowser(_ url: URL) throws {
-        
-        // By asking for the shared instance method by using the "value for key" method on UIApplication, we are able to bypass the Swfit compilation 
-        // restriction that blocks the library from being compiled for an extension when directly referencing it. We do it as an optional so in the 
-        // advent of this method being called, like in an extension, we handle it as though its not supported.
-        guard let application = UIApplication.value(forKey: "sharedApplication") as? UIApplication else {
-            throw OAuth2Error.unableToOpenAuthorizeURL
-        }
-        
-        if !application.openURL(url) {
+		
+		// By asking for the shared instance method by using the "value for key" method on UIApplication, we are able to bypass the Swfit compilation 
+		// restriction that blocks the library from being compiled for an extension when directly referencing it. We do it as an optional so in the 
+		// advent of this method being called, like in an extension, we handle it as though its not supported.
+		guard let application = UIApplication.value(forKey: "sharedApplication") as? UIApplication else {
+			throw OAuth2Error.unableToOpenAuthorizeURL
+		}
+		
+		if !application.openURL(url) {
 			throw OAuth2Error.unableToOpenAuthorizeURL
 		}
 	}

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -54,7 +54,15 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	- throws: UnableToOpenAuthorizeURL on failure
 	*/
 	public func openAuthorizeURLInBrowser(_ url: URL) throws {
-		if !UIApplication.shared.openURL(url) {
+        
+        // By asking for the shared instance method by using the "value for key" method on UIApplication, we are able to bypass the Swfit compilation 
+        // restriction that blocks the library from being compiled for an extension when directly referencing it. We do it as an optional so in the 
+        // advent of this method being called, like in an extension, we handle it as though its not supported.
+        guard let application = UIApplication.value(forKey: "sharedApplication") as? UIApplication else {
+            throw OAuth2Error.unableToOpenAuthorizeURL
+        }
+        
+        if !application.openURL(url) {
 			throw OAuth2Error.unableToOpenAuthorizeURL
 		}
 	}

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -56,7 +56,7 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	public func openAuthorizeURLInBrowser(_ url: URL) throws {
 		
 		// By asking for the shared instance method by using the "value for key" method on UIApplication, we are able to
-		// bypass the Swfit compilation restriction that blocks the library from being compiled for an extension when 
+		// bypass the Swift compilation restriction that blocks the library from being compiled for an extension when 
 		// directly referencing it. We do it as an optional so in the advent of this method being called, like in an 
 		// extension, we handle it as though its not supported.
 		guard let application = UIApplication.value(forKey: "sharedApplication") as? UIApplication else {


### PR DESCRIPTION
…g the "key for value" method on UIApplication to bypass the compiler warnings allowing OAuth2 library to be used within a library that is used as a private framework for an iOS app that has app extensions. This performs an optionality check on UIApplication, so that if its available to be called, it can be called, if not, it throws the appropriate error.

Related to issue #133 