### PR TITLE
Fix for XCode9 assertion error

### DIFF
--- a/Sources/iOS/OAuth2WebViewController.swift
+++ b/Sources/iOS/OAuth2WebViewController.swift
@@ -51,7 +51,7 @@ open class OAuth2WebViewController: UIViewController, WKNavigationDelegate {
 					interceptComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
 				}
 				else {
-					oauth?.logger?.debug("OAuth2", msg: "Failed to parse URL \(interceptURLString!), discarding")
+					oauth?.logger?.debug("OAuth2", msg: "Failed to parse URL \(interceptURLString), discarding")
 					self.interceptURLString = nil
 				}
 			}
@@ -209,6 +209,7 @@ open class OAuth2WebViewController: UIViewController, WKNavigationDelegate {
 				else {
 					decisionHandler(.allow)
 				}
+				return
 			}
 		}
 		decisionHandler(.allow)


### PR DESCRIPTION
When running in iOS 11/XCode 9,  you get an exception if you call 'decisionHandler()' twice.
This strategic return prevents that.

Also - swift 3.2 compile fix for unneeded !