### PR TITLE
Bubble errors up from token fetch

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@ Contributors
 
 Contributors to the codebase, in reverse chronological order:
 
+- David Hardiman, @dhardiman
 - Amaury David, @amaurydavid
 - Lubbo, @lubbo
 - David Everlöf, @everlof

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -109,13 +109,11 @@ open class OAuth2: OAuth2Base {
 		tryToObtainAccessTokenIfNeeded(params: params) { successParams, error in
 			if let successParams = successParams {
 				self.didAuthorize(withParameters: successParams)
+            }
+			else if let error = error {
+				self.didFail(with: error)
 			}
 			else {
-				self.logger?.debug("OAuth2", msg: "Error obtaining token \(String(describing: error))")
-				if let err = error, case .nsError(_) = err {
-					self.didFail(with: error)
-					return
-				}
 				self.registerClientIfNeeded() { json, error in
 					if let error = error {
 						self.didFail(with: error)
@@ -196,7 +194,7 @@ open class OAuth2: OAuth2Base {
 				}
 				else {
 					if let err = error {
-						self.logger?.debug("OAuth2", msg: "\(err)")
+                        self.logger?.debug("OAuth2", msg: "Error refreshing token: \(err)")
 					}
 					callback(nil, error)
 				}

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -111,7 +111,11 @@ open class OAuth2: OAuth2Base {
 				self.didAuthorize(withParameters: successParams)
 			}
 			else {
-                self.logger?.debug("OAuth2", msg: "Error obtaining token \(String(describing: error))")
+				self.logger?.debug("OAuth2", msg: "Error obtaining token \(String(describing: error))")
+				if let err = error, case .nsError(_) = err {
+					self.didFail(with: error)
+					return
+				}
 				self.registerClientIfNeeded() { json, error in
 					if let error = error {
 						self.didFail(with: error)

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -106,11 +106,12 @@ open class OAuth2: OAuth2Base {
 		
 		didAuthorizeOrFail = callback
 		logger?.debug("OAuth2", msg: "Starting authorization")
-		tryToObtainAccessTokenIfNeeded(params: params) { successParams in
+		tryToObtainAccessTokenIfNeeded(params: params) { successParams, error in
 			if let successParams = successParams {
 				self.didAuthorize(withParameters: successParams)
 			}
 			else {
+                self.logger?.debug("OAuth2", msg: "Error obtaining token \(String(describing: error))")
 				self.registerClientIfNeeded() { json, error in
 					if let error = error {
 						self.didFail(with: error)
@@ -178,22 +179,22 @@ open class OAuth2: OAuth2Base {
 	- parameter callback: The callback to call once the client knows whether it has an access token or not; if `success` is true an
 	                      access token is present
 	*/
-	open func tryToObtainAccessTokenIfNeeded(params: OAuth2StringDict? = nil, callback: @escaping ((OAuth2JSON?) -> Void)) {
+	open func tryToObtainAccessTokenIfNeeded(params: OAuth2StringDict? = nil, callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
 		if hasUnexpiredAccessToken() {
 			logger?.debug("OAuth2", msg: "Have an apparently unexpired access token")
-			callback(OAuth2JSON())
+			callback(OAuth2JSON(), nil)
 		}
 		else {
 			logger?.debug("OAuth2", msg: "No access token, checking if a refresh token is available")
 			doRefreshToken(params: params) { successParams, error in
 				if let successParams = successParams {
-					callback(successParams)
+					callback(successParams, nil)
 				}
 				else {
 					if let err = error {
 						self.logger?.debug("OAuth2", msg: "\(err)")
 					}
-					callback(nil)
+					callback(nil, error)
 				}
 			}
 		}

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -109,7 +109,7 @@ open class OAuth2: OAuth2Base {
 		tryToObtainAccessTokenIfNeeded(params: params) { successParams, error in
 			if let successParams = successParams {
 				self.didAuthorize(withParameters: successParams)
-            }
+			}
 			else if let error = error {
 				self.didFail(with: error)
 			}
@@ -194,7 +194,7 @@ open class OAuth2: OAuth2Base {
 				}
 				else {
 					if let err = error {
-                        self.logger?.debug("OAuth2", msg: "Error refreshing token: \(err)")
+						self.logger?.debug("OAuth2", msg: "Error refreshing token: \(err)")
 					}
 					callback(nil, error)
 				}


### PR DESCRIPTION
I'm not sure if this is a pull request you'll want, as I'm not sure whether it's entirely correct behaviour, but I've noticed if a refresh token request gets a networking error, timeout, connection failure etc, then the OAuth mechanism tries to request new credentials rather than just notifying the client of an error. In my app that led us to erroneously log the user out rather than just ignore the error and wait for better network conditions.