### PR TITLE
Fix an issue with decisionHandler called twice

### DIFF
--- a/Sources/macOS/OAuth2WebViewController.swift
+++ b/Sources/macOS/OAuth2WebViewController.swift
@@ -243,6 +243,8 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 				else {
 					decisionHandler(.allow)
 				}
+                
+                return
 			}
 		}
 		

--- a/Sources/macOS/OAuth2WebViewController.swift
+++ b/Sources/macOS/OAuth2WebViewController.swift
@@ -243,8 +243,8 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 				else {
 					decisionHandler(.allow)
 				}
-                
-                return
+				
+				return
 			}
 		}
 		


### PR DESCRIPTION
'NSInternalInconsistencyException', reason: 'Completion handler passed to - [p2_OAuth2.OAuth2WebViewController web.view:decidePolicyForNavigationAction:decisionHandler] - was called more than once'