### PR TITLE
Fixed unauthorized error when refreshing a token

### DIFF
--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -197,7 +197,7 @@ open class OAuth2: OAuth2Base {
 					if let err = error {
 						self.logger?.debug("OAuth2", msg: "Error refreshing token: \(err)")
 						switch err {
-						case .noRefreshToken, .noClientId:
+						case .noRefreshToken, .noClientId, .unauthorizedClient:
 							returnedError = nil
 						default:
 							returnedError = err


### PR DESCRIPTION
If the server sends an unauthorized error when we're trying to refresh a token, it's now handled the same way as not having any refreshToken at all. 
New credentials will the asked (via the `doAuthorize` func) instead of just failing the whole OAuth process.