### PR TITLE
Release 4.0.1 on CocoaPods

### DIFF
--- a/p2.OAuth2.podspec
+++ b/p2.OAuth2.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "p2.OAuth2"
-  s.version      = "3.0.3"
+  s.version      = "4.0.0"
   s.summary      = "OAuth2 framework for macOS, iOS and tvOS, written in Swift."
   s.description  = <<-DESC
                    OAuth2 frameworks for macOS, iOS and tvOS written in Swift.
@@ -35,6 +35,5 @@ Pod::Spec.new do |s|
   s.osx.source_files = "Sources/macOS/*.swift"
   s.tvos.source_files = "Sources/tvOS/*.swift"
 
- #s.dependency "SwiftKeychain", "~> 1.0"
   s.ios.framework = "SafariServices"
 end

--- a/p2.OAuth2.podspec
+++ b/p2.OAuth2.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "p2.OAuth2"
-  s.version      = "4.0.0"
+  s.version      = "4.0.1"
   s.summary      = "OAuth2 framework for macOS, iOS and tvOS, written in Swift."
   s.description  = <<-DESC
                    OAuth2 frameworks for macOS, iOS and tvOS written in Swift.


### PR DESCRIPTION
We have 2 choices here:
- Set the spec version to 4.0.0, move the github tag to this commit (once merged), and then push the spec.
- Set the spec version to 4.0.1, release this new version on github and push the spec.

I'd recommend the 2nd option, as there have been some changes/fixes to master since 4.0.0 was released.