### PR TITLE
A more standard appearance/location for the Cancel button

### DIFF
--- a/Sources/macOS/OAuth2WebViewController.swift
+++ b/Sources/macOS/OAuth2WebViewController.swift
@@ -127,7 +127,7 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 		
 		view.addSubview(webView)
 		view.addConstraint(NSLayoutConstraint(item: webView, attribute: .top, relatedBy: .equal, toItem: view, attribute: .top, multiplier: 1.0, constant: 0.0))
-		view.addConstraint(NSLayoutConstraint(item: webView, attribute: .bottom, relatedBy: .equal, toItem: view, attribute: .bottom, multiplier: 1.0, constant: 0.0))
+		view.addConstraint(NSLayoutConstraint(item: webView, attribute: .bottom, relatedBy: .equal, toItem: view, attribute: .bottom, multiplier: 1.0, constant: (willBecomeSheet ? -40.0 : 0.0)))
 		view.addConstraint(NSLayoutConstraint(item: webView, attribute: .left, relatedBy: .equal, toItem: view, attribute: .left, multiplier: 1.0, constant: 0.0))
 		view.addConstraint(NSLayoutConstraint(item: webView, attribute: .right, relatedBy: .equal, toItem: view, attribute: .right, multiplier: 1.0, constant: 0.0))
 		
@@ -136,6 +136,7 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 			let button = NSButton(frame: NSRect(x: 0, y: 0, width: 120, height: 20))
 			button.translatesAutoresizingMaskIntoConstraints = false
 			button.title = "Cancel"
+			button.bezelStyle = .rounded
 			button.target = self
 			button.action = #selector(OAuth2WebViewController.cancel(_:))
 			view.addSubview(button)


### PR DESCRIPTION
Hi, p2/OAuth2!

I was playing with the sample Mac app, and the functionally is perfectly fine, but the visual style of the "Cancel" button seemed rather out of place, so I've made a couple tiny changes to make it appear more like a standard Cancel button.

Before:
![before](https://user-images.githubusercontent.com/22565/33043298-d31579d8-cdf9-11e7-9d6a-7e02daef72ca.png)

After:
![after](https://user-images.githubusercontent.com/22565/33043305-d8118f4e-cdf9-11e7-8d8f-64cad35340fe.png)
