### PR TITLE
Return OAuth error codes with description

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@ Contributors
 
 Contributors to the codebase, in reverse chronological order:
 
+- Seb Skuse, @sebskuse
 - David Hardiman, @dhardiman
 - Amaury David, @amaurydavid
 - Lubbo, @lubbo

--- a/Sources/Base/OAuth2Base.swift
+++ b/Sources/Base/OAuth2Base.swift
@@ -311,8 +311,8 @@ open class OAuth2Base: OAuth2Securable {
 	- returns: An OAuth2Error
 	*/
 	open func assureNoErrorInResponse(_ params: OAuth2JSON, fallback: String? = nil) throws {
-        let err_code = params["error"] as? String
-        let err_msg = params["error_description"] as? String
+		let err_code = params["error"] as? String
+		let err_msg = params["error_description"] as? String
 
 		// "error_description" is optional, we use it if it's present and code is not.
 		if let message = err_msg, message.count > 0 && (err_code?.isEmpty ?? true) {
@@ -321,7 +321,7 @@ open class OAuth2Base: OAuth2Securable {
 
 		// the "error" response is required for error responses, so it should be present
 		if let code = err_code, code.count > 0 {
-            throw OAuth2Error.fromResponseError(code, description: err_msg, fallback: fallback)
+			throw OAuth2Error.fromResponseError(code, description: err_msg, fallback: fallback)
 		}
 	}
 	

--- a/Sources/Base/OAuth2Base.swift
+++ b/Sources/Base/OAuth2Base.swift
@@ -311,15 +311,17 @@ open class OAuth2Base: OAuth2Securable {
 	- returns: An OAuth2Error
 	*/
 	open func assureNoErrorInResponse(_ params: OAuth2JSON, fallback: String? = nil) throws {
-		
-		// "error_description" is optional, we prefer it if it's present
-		if let err_msg = params["error_description"] as? String, err_msg.count > 0 {
-			throw OAuth2Error.responseError(err_msg)
+        let err_code = params["error"] as? String
+        let err_msg = params["error_description"] as? String
+
+		// "error_description" is optional, we use it if it's present and code is not.
+		if let message = err_msg, message.count > 0 && (err_code?.isEmpty ?? true) {
+			throw OAuth2Error.responseError(message)
 		}
-		
+
 		// the "error" response is required for error responses, so it should be present
-		if let err_code = params["error"] as? String {
-			throw OAuth2Error.fromResponseError(err_code, fallback: fallback)
+		if let code = err_code, code.count > 0 {
+            throw OAuth2Error.fromResponseError(code, description: err_msg, fallback: fallback)
 		}
 	}
 	

--- a/Sources/Base/OAuth2Error.swift
+++ b/Sources/Base/OAuth2Error.swift
@@ -154,7 +154,8 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 	/// The service is temporarily unavailable.
 	case temporarilyUnavailable(String?)
 
-    case invalidGrant(String?)
+	/// Invalid grant.
+	case invalidGrant(String?)
 
 	/// Other response error, as defined in its String.
 	case responseError(String)
@@ -164,11 +165,11 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 	Instantiate the error corresponding to the OAuth2 response code, if it is known.
 	
 	- parameter code: The code, like "access_denied", that should be interpreted
-    - parameter description: The description provided in the response
+	- parameter description: The description provided in the response
 	- parameter fallback: The error string to use in case the error code is not known
 	- returns: An appropriate OAuth2Error
 	*/
-    public static func fromResponseError(_ code: String, description: String? = nil, fallback: String? = nil) -> OAuth2Error {
+	public static func fromResponseError(_ code: String, description: String? = nil, fallback: String? = nil) -> OAuth2Error {
 		switch code {
 		case "invalid_request":
 			return .invalidRequest(description)
@@ -184,8 +185,8 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 			return .serverError
 		case "temporarily_unavailable":
 			return .temporarilyUnavailable(description)
-        case "invalid_grant":
-            return .invalidGrant(description)
+		case "invalid_grant":
+			return .invalidGrant(description)
 		default:
 			return .responseError(description ?? fallback ?? "Authorization error: \(code)")
 		}
@@ -274,8 +275,8 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 			return "The authorization server encountered an unexpected condition that prevented it from fulfilling the request."
 		case .temporarilyUnavailable(let message):
 			return message ?? "The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server."
-        case .invalidGrant(let message):
-            return message ?? "The authorization grant or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
+		case .invalidGrant(let message):
+			return message ?? "The authorization grant or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
 		case .responseError(let message):
 			return message
 		}
@@ -324,7 +325,7 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 		case (.invalidScope(let lhm), .invalidScope(let rhm)):                   return lhm == rhm
 		case (.serverError, .serverError):                           return true
 		case (.temporarilyUnavailable(let lhm), .temporarilyUnavailable(let rhm)):     return lhm == rhm
-        case (.invalidGrant(let lhm), .invalidGrant(let rhm)):       return lhm == rhm
+		case (.invalidGrant(let lhm), .invalidGrant(let rhm)):       return lhm == rhm
 		case (.responseError(let lhm), .responseError(let rhm)):     return lhm == rhm
 		default:                                                     return false
 		}

--- a/Sources/Base/OAuth2Error.swift
+++ b/Sources/Base/OAuth2Error.swift
@@ -91,7 +91,7 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 	/// Unable to open the authorize URL.
 	case unableToOpenAuthorizeURL
 	
-	/// The request is invalid.
+	/// The request is invalid. Passes the underlying error_description.
 	case invalidRequest(String?)
 	
 	/// The request was canceled.
@@ -103,7 +103,7 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 	/// There was no token type in the response.
 	case noTokenType
 	
-	/// The token type is not supported.
+	/// The token type is not supported. Passes the underlying error_description.
 	case unsupportedTokenType(String)
 	
 	/// There was no data in the response.
@@ -130,7 +130,7 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 	
 	// MARK: - OAuth2 errors
 	
-	/// The client is unauthorized (HTTP status 401).
+	/// The client is unauthorized (HTTP status 401). Passes the underlying error_description.
 	case unauthorizedClient(String?)
 	
 	/// The request was forbidden (HTTP status 403).
@@ -139,22 +139,22 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 	/// Username or password was wrong (HTTP status 403 on password grant).
 	case wrongUsernamePassword
 	
-	/// Access was denied.
+	/// Access was denied. Passes the underlying error_description.
 	case accessDenied(String?)
 	
-	/// Response type is not supported.
+	/// Response type is not supported. Passes the underlying error_description.
 	case unsupportedResponseType(String?)
 	
-	/// Scope was invalid.
+	/// Scope was invalid. Passes the underlying error_description.
 	case invalidScope(String?)
 	
 	/// A 500 was thrown.
 	case serverError
 	
-	/// The service is temporarily unavailable.
+	/// The service is temporarily unavailable. Passes the underlying error_description.
 	case temporarilyUnavailable(String?)
 
-	/// Invalid grant.
+	/// Invalid grant. Passes the underlying error_description.
 	case invalidGrant(String?)
 
 	/// Other response error, as defined in its String.

--- a/Sources/Base/OAuth2Requestable.swift
+++ b/Sources/Base/OAuth2Requestable.swift
@@ -197,10 +197,10 @@ open class OAuth2Requestable {
 	- returns: A dictionary full of strings with the key-value pairs found in the query
 	*/
 	public final class func params(fromQuery query: String) -> OAuth2StringDict {
-		let parts = query.characters.split() { $0 == "&" }.map() { String($0) }
+		let parts = query.split() { $0 == "&" }.map() { String($0) }
 		var params = OAuth2StringDict(minimumCapacity: parts.count)
 		for part in parts {
-			let subparts = part.characters.split() { $0 == "=" }.map() { String($0) }
+			let subparts = part.split() { $0 == "=" }.map() { String($0) }
 			if 2 == subparts.count {
 				params[subparts[0]] = subparts[1].wwwFormURLDecodedString
 			}

--- a/Sources/Base/OAuth2Response.swift
+++ b/Sources/Base/OAuth2Response.swift
@@ -86,7 +86,7 @@ open class OAuth2Response {
 			throw error
 		}
 		else if 401 == response.statusCode {
-			throw OAuth2Error.unauthorizedClient
+			throw OAuth2Error.unauthorizedClient(nil)
 		}
 		else if 403 == response.statusCode {
 			throw OAuth2Error.forbidden

--- a/Sources/DataLoader/OAuth2DataLoader.swift
+++ b/Sources/DataLoader/OAuth2DataLoader.swift
@@ -115,7 +115,7 @@ open class OAuth2DataLoader: OAuth2Requestable {
 		super.perform(request: request) { response in
 			do {
 				if self.alsoIntercept403, 403 == response.response.statusCode {
-					throw OAuth2Error.unauthorizedClient
+					throw OAuth2Error.unauthorizedClient(nil)
 				}
 				let _ = try response.responseData()
 				callback(response)

--- a/Sources/Flows/OAuth2CodeGrant.swift
+++ b/Sources/Flows/OAuth2CodeGrant.swift
@@ -133,7 +133,7 @@ open class OAuth2CodeGrant: OAuth2 {
 		if !(redirect.absoluteString.hasPrefix(expectRedirect)) && (!(redirect.absoluteString.hasPrefix("urn:ietf:wg:oauth:2.0:oob")) && "localhost" != comp?.host) {
 			throw OAuth2Error.invalidRedirectURL("Expecting «\(expectRedirect)» but received «\(redirect)»")
 		}
-		if let compQuery = comp?.query, compQuery.characters.count > 0 {
+		if let compQuery = comp?.query, compQuery.count > 0 {
 			let query = OAuth2CodeGrant.params(fromQuery: comp!.percentEncodedQuery!)
 			try assureNoErrorInResponse(query as OAuth2JSON)
 			if let cd = query["code"] {

--- a/Sources/Flows/OAuth2ImplicitGrant.swift
+++ b/Sources/Flows/OAuth2ImplicitGrant.swift
@@ -42,7 +42,7 @@ open class OAuth2ImplicitGrant: OAuth2 {
 		do {
 			// token should be in the URL fragment
 			let comp = URLComponents(url: redirect, resolvingAgainstBaseURL: true)
-			guard let fragment = comp?.percentEncodedFragment, fragment.characters.count > 0 else {
+			guard let fragment = comp?.percentEncodedFragment, fragment.count > 0 else {
 				throw OAuth2Error.invalidRedirectURL(redirect.description)
 			}
 			

--- a/Tests/BaseTests/OAuth2Tests.swift
+++ b/Tests/BaseTests/OAuth2Tests.swift
@@ -134,7 +134,7 @@ class OAuth2Tests: XCTestCase {
 	
 	func testQueryParamConversion() {
 		let qry = OAuth2RequestParams.formEncodedQueryStringFor(["a": "AA", "b": "BB", "x": "yz"])
-		XCTAssertEqual(14, qry.characters.count, "Expecting a 14 character string")
+		XCTAssertEqual(14, qry.count, "Expecting a 14 character string")
 		
 		let dict = OAuth2.params(fromQuery: qry)
 		XCTAssertEqual(dict["a"]!, "AA", "Must unpack `a`")
@@ -144,7 +144,7 @@ class OAuth2Tests: XCTestCase {
 	
 	func testQueryParamEncoding() {
 		let qry = OAuth2RequestParams.formEncodedQueryStringFor(["uri": "https://api.io", "str": "a string: cool!", "num": "3.14159"])
-		XCTAssertEqual(60, qry.characters.count, "Expecting a 60 character string")
+		XCTAssertEqual(60, qry.count, "Expecting a 60 character string")
 		
 		let dict = OAuth2.params(fromQuery: qry)
 		XCTAssertEqual(dict["uri"]!, "https://api.io", "Must correctly unpack `uri`")

--- a/Tests/FlowTests/OAuth2CodeGrantTests.swift
+++ b/Tests/FlowTests/OAuth2CodeGrantTests.swift
@@ -94,7 +94,7 @@ class OAuth2CodeGrantTests: XCTestCase {
 		XCTAssertNil(query["client_secret"], "Must not have `client_secret`")
 		XCTAssertEqual(query["response_type"]!, "code", "Expecting correct `response_type`")
 		XCTAssertEqual(query["redirect_uri"]!, "oauth2://callback", "Expecting correct `redirect_uri`")
-		XCTAssertTrue(8 == (query["state"]!).characters.count, "Expecting an auto-generated UUID for `state`")
+		XCTAssertTrue(8 == (query["state"]!).count, "Expecting an auto-generated UUID for `state`")
 	}
 	
 	func testRedirectURI() {

--- a/Tests/FlowTests/OAuth2DynRegTests.swift
+++ b/Tests/FlowTests/OAuth2DynRegTests.swift
@@ -114,7 +114,7 @@ class OAuth2DynRegTests: XCTestCase {
 
 class OAuth2TestDynReg: OAuth2DynReg {
 	override func register(client: OAuth2, callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
-		callback(nil, OAuth2Error.temporarilyUnavailable)
+		callback(nil, OAuth2Error.temporarilyUnavailable(nil))
 	}
 }
 

--- a/Tests/FlowTests/OAuth2ImplicitGrantTests.swift
+++ b/Tests/FlowTests/OAuth2ImplicitGrantTests.swift
@@ -80,7 +80,7 @@ class OAuth2ImplicitGrantTests: XCTestCase
 		oauth.didAuthorizeOrFail = { authParameters, error in
 			XCTAssertNil(authParameters, "Nil auth dict expected")
 			XCTAssertNotNil(error, "Error message expected")
-			XCTAssertEqual(error, OAuth2Error.accessDenied)
+			XCTAssertEqual(error, OAuth2Error.accessDenied(nil))
 			XCTAssertEqual(error?.description, "The resource owner or authorization server denied the request.")
 		}
 		oauth.handleRedirectURL(URL(string: "https://auth.ful.io#error=access_denied")!)


### PR DESCRIPTION
Hi! 

We've encountered an issue where we'd like to know when we encounter an `invalid_grant` error from a token refresh call. 

As it stands, because the error response contains an `error_description`, `OAuth2Base` is passing this string back to us wrapped in a `.responseError`. We'd prefer not to use the description string, as we can't guarantee it won't change, and it's [only meant as a human readable string](https://tools.ietf.org/html/rfc6749#section-5.2).

This PR changes the behaviour in error detection to pass back a strongly typed `OAuth2Error` if we can, along with the `error_description` as an associated value. It also adds a new `OAuth2Error` case, `.invalidGrant`.

I've also fixed up a couple of Swift 4 warnings related to the use of `.characters`.