### PR TITLE
Added in clarity for response errors on password grant obtainAccessToken method.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@ Contributors to the codebase, in reverse chronological order:
 - Tim Sneed, @trsneed
 - Vojto Rinik, @vojto
 - Paul Wilkinson, @paulw11
+- Jay Cohen, @theswiftycoder

--- a/Sources/Flows/OAuth2PasswordGrant.swift
+++ b/Sources/Flows/OAuth2PasswordGrant.swift
@@ -240,11 +240,17 @@ open class OAuth2PasswordGrant: OAuth2 {
 					self.logger?.debug("OAuth2", msg: "Did get access token [\(nil != self.clientConfig.accessToken)]")
 					callback(dict, nil)
 				}
-				catch OAuth2Error.unauthorizedClient {     // TODO: which one is it?
+				catch OAuth2Error.unauthorizedClient {
+					callback(nil, OAuth2Error.unauthorizedClient)
+				}
+				catch OAuth2Error.grantType {
+					callback(nil, OAuth2Error.grantType)
+				}
+				catch OAuth2Error.wrongUsernamePassword {
 					callback(nil, OAuth2Error.wrongUsernamePassword)
 				}
-				catch OAuth2Error.forbidden {              // TODO: which one is it?
-					callback(nil, OAuth2Error.wrongUsernamePassword)
+				catch OAuth2Error.forbidden {
+					callback(nil, OAuth2Error.forbidden)
 				}
 				catch let error {
 					self.logger?.debug("OAuth2", msg: "Error obtaining access token: \(error)")

--- a/Sources/Flows/OAuth2PasswordGrant.swift
+++ b/Sources/Flows/OAuth2PasswordGrant.swift
@@ -243,9 +243,6 @@ open class OAuth2PasswordGrant: OAuth2 {
 				catch OAuth2Error.unauthorizedClient {
 					callback(nil, OAuth2Error.unauthorizedClient)
 				}
-				catch OAuth2Error.grantType {
-					callback(nil, OAuth2Error.grantType)
-				}
 				catch OAuth2Error.wrongUsernamePassword {
 					callback(nil, OAuth2Error.wrongUsernamePassword)
 				}


### PR DESCRIPTION
Existing structure under client credentials failing would produce a `wrongUsernamePassword` error.
Tested!