### PR TITLE
Handle cases where token is returned in query

### DIFF
--- a/Sources/Flows/OAuth2ImplicitGrant.swift
+++ b/Sources/Flows/OAuth2ImplicitGrant.swift
@@ -42,11 +42,16 @@ open class OAuth2ImplicitGrant: OAuth2 {
 		do {
 			// token should be in the URL fragment
 			let comp = URLComponents(url: redirect, resolvingAgainstBaseURL: true)
-			guard let fragment = comp?.percentEncodedFragment, fragment.count > 0 else {
+            		let queryComponent: String
+			if let fragment = comp?.percentEncodedFragment, fragment.count > 0 {
+                		queryComponent = fragment
+            		} else if let query = comp?.query, query.count > 0 {
+                		queryComponent = query
+            		} else {
 				throw OAuth2Error.invalidRedirectURL(redirect.description)
 			}
 			
-			let params = type(of: self).params(fromQuery: fragment)
+			let params = type(of: self).params(fromQuery: queryComponent)
 			let dict = try parseAccessTokenResponse(params: params)
 			logger?.debug("OAuth2", msg: "Successfully extracted access token")
 			didAuthorize(withParameters: dict)


### PR DESCRIPTION
I encountered an API (Harvest) that returns the token in the query instead of the fragment. This change handles both cases, giving preference to the fragment over the query.