### PR TITLE
ClientConfig: Warn about invalid settings

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@ Contributors
 
 Contributors to the codebase, in reverse chronological order:
 
+- Max Bruckner, @FSMaxB-divae
 - Seb Skuse, @sebskuse
 - David Hardiman, @dhardiman
 - Amaury David, @amaurydavid

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -139,6 +139,10 @@ open class OAuth2ClientConfig {
 		if let assume = settings["token_assume_unexpired"] as? Bool {
 			accessTokenAssumeUnexpired = assume
 		}
+
+		guard (clientSecret == nil) || (clientId != nil) else {
+			fatalError("clientSecret is set but clientId is missing.")
+		}
 	}
 	
 	


### PR DESCRIPTION
Given my embarrassing mistake in #264 I thought it might be useful to add a warning about invalid settings.

Not sure if this can be merged as is. I had to create a new logger instance in `OAuth2ClientConfig.init` because I didn't know how else to get access to a logger.