### PR TITLE
Add alsoIntercept400

### DIFF
--- a/Sources/DataLoader/OAuth2DataLoader.swift
+++ b/Sources/DataLoader/OAuth2DataLoader.swift
@@ -35,7 +35,9 @@ open class OAuth2DataLoader: OAuth2Requestable {
 	
 	/// If set to true, a 403 is treated as a 401. The default is false.
 	public var alsoIntercept403: Bool = false
-	
+    
+    /// If set to true, a 400 is treated as a 401. The default is false.
+    public var alsoIntercept400: Bool = false
 	
 	/**
 	Designated initializer.
@@ -103,7 +105,7 @@ open class OAuth2DataLoader: OAuth2Requestable {
 	    }
 	
 	- parameter request:  The request to execute
-	- parameter retry:    Whether the request should be retried on 401 (and possibly 403)
+	- parameter retry:    Whether the request should be retried on 401 (and possibly 400, 403)
 	- parameter callback: The callback to call when the request completes/fails
 	*/
 	open func perform(request: URLRequest, retry: Bool, callback: @escaping ((OAuth2Response) -> Void)) {
@@ -117,7 +119,10 @@ open class OAuth2DataLoader: OAuth2Requestable {
 				if self.alsoIntercept403, 403 == response.response.statusCode {
 					throw OAuth2Error.unauthorizedClient(nil)
 				}
-				let _ = try response.responseData()
+                if self.alsoIntercept400, 400 == response.response.statusCode {
+                    throw OAuth2Error.unauthorizedClient(nil)
+                }
+                let _ = try response.responseData()
 				callback(response)
 			}
 			


### PR DESCRIPTION
Hi. I'm p2/oauth2 user for Dropbox API with Implicit grant flow.

I got a problem in OAuth2DataLoader class. But this is not p2/oauth2 fault.
Usually, dropbox have to return 401 or 403, Dropbox was return HTTP 400 (Bad request) in first time access.

![No AccessToken in first time](https://i.imgur.com/rgNux6N.png)


To access Dropbox 400 must be treated as 401...

Please check it. Thx!
