### PR TITLE
Make oauth2 a strong reference

### DIFF
--- a/Sources/Base/OAuth2AuthorizerUI.swift
+++ b/Sources/Base/OAuth2AuthorizerUI.swift
@@ -27,7 +27,7 @@ Platform-dependent authorizers must adopt this protocol.
 public protocol OAuth2AuthorizerUI {
 	
 	/// The OAuth2 instance this authorizer belongs to.
-	unowned var oauth2: OAuth2Base { get }
+	var oauth2: OAuth2Base { get }
 	
 	/**
 	Open the authorize URL in the OS browser.


### PR DESCRIPTION
'unowned' should not be applied to property declaration in a protocol
and this will actually lead to a crash when you set "keychain: false" in
oauth2 settings.