### PR TITLE
Add compiler flag to disable UIApplication calls

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@ Contributors
 
 Contributors to the codebase, in reverse chronological order:
 
+- Maxime Le Moine, @MaximeLM
 - Seb Skuse, @sebskuse
 - David Hardiman, @dhardiman
 - Amaury David, @amaurydavid

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -56,15 +56,7 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	public func openAuthorizeURLInBrowser(_ url: URL) throws {
 		
 		#if !P2_APP_EXTENSIONS
-		// By asking for the shared instance method by using the "value for key" method on UIApplication, we are able to
-		// bypass the Swift compilation restriction that blocks the library from being compiled for an extension when 
-		// directly referencing it. We do it as an optional so in the advent of this method being called, like in an 
-		// extension, we handle it as though its not supported.
-		guard let application = UIApplication.value(forKey: "sharedApplication") as? UIApplication else {
-			throw OAuth2Error.unableToOpenAuthorizeURL
-		}
-		
-		if !application.openURL(url) {
+		if !UIApplication.shared.openURL(url) {
 			throw OAuth2Error.unableToOpenAuthorizeURL
 		}
 		#else

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -55,6 +55,7 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	*/
 	public func openAuthorizeURLInBrowser(_ url: URL) throws {
 		
+		#if !P2_APP_EXTENSIONS
 		// By asking for the shared instance method by using the "value for key" method on UIApplication, we are able to
 		// bypass the Swift compilation restriction that blocks the library from being compiled for an extension when 
 		// directly referencing it. We do it as an optional so in the advent of this method being called, like in an 
@@ -66,6 +67,7 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 		if !application.openURL(url) {
 			throw OAuth2Error.unableToOpenAuthorizeURL
 		}
+		#endif
 	}
 	
 	/**

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -67,6 +67,8 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 		if !application.openURL(url) {
 			throw OAuth2Error.unableToOpenAuthorizeURL
 		}
+		#else
+		throw OAuth2Error.unableToOpenAuthorizeURL
 		#endif
 	}
 	


### PR DESCRIPTION
Fixes #275 with the solution initially proposed in #133.

App extensions users will be able to add a `P2_APP_EXTENSIONS` compiler flag to the p2.OAuth2 target to disable UIApplication calls.