### PR TITLE
Fix exception on WKNavigationDelegate method

### DIFF
--- a/Sources/iOS/OAuth2WebViewController.swift
+++ b/Sources/iOS/OAuth2WebViewController.swift
@@ -211,8 +211,9 @@ open class OAuth2WebViewController: UIViewController, WKNavigationDelegate {
 				}
 				return
 			}
-		}
-		decisionHandler(.allow)
+        } else {
+            decisionHandler(.allow)
+        }
 	}
 	
 	open func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {


### PR DESCRIPTION
Fix exception thrown on webView(_:decidePolicyforNavigationAction:decisionHandler:) due to double call to decisionHandler.