### PR TITLE
Update version in sample configurations of the README to 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ The preferred way is to use _git_ directly or _Carthage_.
 Installation via Carthage is easy enough:
 
 ```ruby
-github "p2/OAuth2" ~> 3.0
+github "p2/OAuth2" ~> 4.2
 ```
 
 #### git
@@ -514,7 +514,7 @@ If you're unfamiliar with CocoaPods, read [using CocoaPods](http://guides.cocoap
 platform :ios, '8.0'          # or platform :osx, '10.9'
 use_frameworks!
 target `YourApp` do
-  pod 'p2.OAuth2', '~> 3.0'
+  pod 'p2.OAuth2', '~> 4.2'
 end
 ```
 


### PR DESCRIPTION
This makes sure that users who are new to the project start using the new version.
Otherwise, if they use Swift 4.2, they will not be able to successfully build
their project.

Yes, this is rather minor change, but it would've helped me when I got started using the `OAuth2` in my own project. Please feel free to decline this PR if there's a reason for people to continue using version 3.0.

Thanks in advance for your effort!