### PR TITLE
Added the missing custom parameters to authorizeRequest

### DIFF
--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -285,6 +285,7 @@ open class OAuth2: OAuth2Base {
 		if clientConfig.safariCancelWorkaround {
 			req.params["swa"] = "\(Date.timeIntervalSinceReferenceDate)" // Safari issue workaround
 		}
+		req.add(params: authParameters)
 		req.add(params: params)
 		
 		return req

--- a/Tests/FlowTests/OAuth2CodeGrantTests.swift
+++ b/Tests/FlowTests/OAuth2CodeGrantTests.swift
@@ -280,6 +280,12 @@ class OAuth2CodeGrantTests: XCTestCase {
 		let body3 = String(data: req3.httpBody!, encoding: String.Encoding.utf8)
 		let query3 = OAuth2CodeGrant.params(fromQuery: body3!)
 		XCTAssertEqual(query3["bar"], "hat", "Expecting key `bar` to be `hat`")
+
+		oauth.authParameters = ["hat": "trick"]
+
+		// in authorize request
+		let req4 = try! oauth.authorizeRequest(withRedirect: "pp", scope: nil, params: nil)
+		XCTAssertEqual(req4.params["hat"], "trick", "Expecting key `hat` to be `trick`")
 	}
 	
 	func testCustomAuthParametersInit() {


### PR DESCRIPTION
`authorizeRequest(withRedirect:scope:params:)`, the part that actually gets called during authorization, does not seem to be using the provided custom parameters.

In reddit's case it's impossible to specify "duration": "permanent" since it'll never get added to the request.

same problem in older versions:
https://github.com/p2/OAuth2/issues/26
https://github.com/p2/OAuth2/issues/221