### PR TITLE
Use SPM version of Keychain

### DIFF
--- a/OAuth2.xcodeproj/project.pbxproj
+++ b/OAuth2.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		6598545C1C5B3CAB00237D39 /* OAuth2DebugURLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29EABB195A0DB2008882C8 /* OAuth2DebugURLSessionDelegate.swift */; };
 		6598545D1C5B3CAB00237D39 /* OAuth2Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE79F6591BFAA36900746243 /* OAuth2Error.swift */; };
 		6598545E1C5B3CAB00237D39 /* extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDB864B19421DAD00C4EEA1 /* extensions.swift */; };
-		659854611C5B3CB900237D39 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC7A8D01AE4851E008C30E7 /* Keychain.swift */; };
 		65EC05E01C9050CB00DE9186 /* OAuth2KeychainAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EC05DF1C9050CB00DE9186 /* OAuth2KeychainAccount.swift */; };
 		65EC05E11C9050CB00DE9186 /* OAuth2KeychainAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EC05DF1C9050CB00DE9186 /* OAuth2KeychainAccount.swift */; };
 		65EC05E21C9050CB00DE9186 /* OAuth2KeychainAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EC05DF1C9050CB00DE9186 /* OAuth2KeychainAccount.swift */; };
@@ -108,8 +107,6 @@
 		EEC6D57D1C2837EA00FA9B1C /* OAuth2CodeGrantLinkedIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC6D57B1C2837EA00FA9B1C /* OAuth2CodeGrantLinkedIn.swift */; };
 		EEC7A8C71AE46C33008C30E7 /* OAuth2Authorizer+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC7A8C61AE46C33008C30E7 /* OAuth2Authorizer+macOS.swift */; };
 		EEC7A8C91AE47111008C30E7 /* OAuth2Authorizer+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC7A8C81AE47111008C30E7 /* OAuth2Authorizer+iOS.swift */; };
-		EEC7A8D81AE4851E008C30E7 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC7A8D01AE4851E008C30E7 /* Keychain.swift */; };
-		EEC7A8D91AE4851E008C30E7 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC7A8D01AE4851E008C30E7 /* Keychain.swift */; };
 		EEF47D2B1B1E3FDD0057D838 /* OAuth2Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF47D2A1B1E3FDD0057D838 /* OAuth2Requestable.swift */; };
 		EEF47D2C1B1E3FDD0057D838 /* OAuth2Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF47D2A1B1E3FDD0057D838 /* OAuth2Requestable.swift */; };
 		EEFD23511C9ED9E400727DCF /* OAuth2ClientCredentialsReddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFD23501C9ED9E400727DCF /* OAuth2ClientCredentialsReddit.swift */; };
@@ -214,7 +211,6 @@
 		EEC6D57B1C2837EA00FA9B1C /* OAuth2CodeGrantLinkedIn.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2CodeGrantLinkedIn.swift; sourceTree = "<group>"; };
 		EEC7A8C61AE46C33008C30E7 /* OAuth2Authorizer+macOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "OAuth2Authorizer+macOS.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		EEC7A8C81AE47111008C30E7 /* OAuth2Authorizer+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "OAuth2Authorizer+iOS.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		EEC7A8D01AE4851E008C30E7 /* Keychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Keychain.swift; path = ../../SwiftKeychain/Keychain/Keychain.swift; sourceTree = "<group>"; };
 		EEC7A8E01AE48533008C30E7 /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		EEDB8624193FAAE500C4EEA1 /* OAuth2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuth2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EEDB8640193FAB9200C4EEA1 /* OAuth2Base.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = OAuth2Base.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -372,14 +368,6 @@
 			path = macOS;
 			sourceTree = "<group>";
 		};
-		EEC7A8CD1AE4851E008C30E7 /* SwiftKeychain */ = {
-			isa = PBXGroup;
-			children = (
-				EEC7A8D01AE4851E008C30E7 /* Keychain.swift */,
-			);
-			path = SwiftKeychain;
-			sourceTree = "<group>";
-		};
 		EEDB861A193FAAE500C4EEA1 = {
 			isa = PBXGroup;
 			children = (
@@ -417,7 +405,6 @@
 				EE2486281AC85DD4002B31AF /* iOS */,
 				EEC7A8C51AE46C33008C30E7 /* macOS */,
 				65D294B91C57CB47009DA970 /* tvOS */,
-				EEC7A8CD1AE4851E008C30E7 /* SwiftKeychain */,
 				EEDB8627193FAAE500C4EEA1 /* Supporting Files */,
 			);
 			name = OAuth2;
@@ -657,7 +644,6 @@
 				6598545A1C5B3CA700237D39 /* OAuth2PasswordGrant.swift in Sources */,
 				EE429D8E1E65721000BC6F67 /* OAuth2CustomAuthorizer+tvOS.swift in Sources */,
 				659854551C5B3CA700237D39 /* OAuth2CodeGrantFacebook.swift in Sources */,
-				659854611C5B3CB900237D39 /* Keychain.swift in Sources */,
 				EEB9A9851D86D36A0022EF66 /* OAuth2RequestPerformer.swift in Sources */,
 				659854561C5B3CA700237D39 /* OAuth2CodeGrantLinkedIn.swift in Sources */,
 				6598545D1C5B3CAB00237D39 /* OAuth2Error.swift in Sources */,
@@ -683,7 +669,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				EEACE1DD1A7E8DF7009BF3A7 /* extensions.swift in Sources */,
-				EEC7A8D91AE4851E008C30E7 /* Keychain.swift in Sources */,
 				EEAEF10C1CDBCF28001A1C6F /* OAuth2Logger.swift in Sources */,
 				EE20118D1E44D0BD00913FA7 /* OAuth2DataLoaderSessionTaskDelegate.swift in Sources */,
 				65EC05E11C9050CB00DE9186 /* OAuth2KeychainAccount.swift in Sources */,
@@ -723,7 +708,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				EEACE1DC1A7E8DF6009BF3A7 /* extensions.swift in Sources */,
-				EEC7A8D81AE4851E008C30E7 /* Keychain.swift in Sources */,
 				EEAEF10B1CDBCF28001A1C6F /* OAuth2Logger.swift in Sources */,
 				65EC05E01C9050CB00DE9186 /* OAuth2KeychainAccount.swift in Sources */,
 				0C2F5E5B1DE2DB8500F621E0 /* OAuth2CodeGrantAzure.swift in Sources */,

--- a/OAuth2.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/OAuth2.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftKeychain",
+        "repositoryURL": "https://github.com/hermanbanken/SwiftKeychain.git",
+        "state": {
+          "branch": null,
+          "revision": "bdd183f17741f351dd6d201b73b236db3e143775",
+          "version": "1.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:4.0
 //
 //  Package.swift
 //  OAuth2
@@ -21,16 +22,15 @@
 import PackageDescription
 
 let package = Package(
-	name: "OAuth2",
+    name: "OAuth2",
+    dependencies: [
+        // SwiftKeychain is not yet available as a Package, so we symlink to /Sources and make it a Target
+        .package(url: "https://github.com/hermanbanken/SwiftKeychain.git", from: "1.0.1"),
+    ],
 	targets: [
-		Target(name: "SwiftKeychain"),
-		Target(name: "Base", dependencies: [.Target(name: "SwiftKeychain")]),
-		Target(name: "macOS", dependencies: [.Target(name: "Base")]),
-		Target(name: "Flows", dependencies: [.Target(name: "macOS")]),
-		Target(name: "DataLoader", dependencies: [.Target(name: "Flows")]),
-	],
-	dependencies: [
-		// SwiftKeychain is not yet available as a Package, so we symlink to /Sources and make it a Target
-		//.Package(url: "https://github.com/yankodimitrov/SwiftKeychain.git", majorVersion: 1),
+		.target(name: "Base", dependencies: ["SwiftKeychain"]),
+		.target(name: "macOS", dependencies: [.target(name: "Base")]),
+		.target(name: "Flows", dependencies: [.target(name: "macOS")]),
+		.target(name: "DataLoader", dependencies: [.target(name: "Flows")]),
 	]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,6 @@ let package = Package(
     .library(name: "OAuth2", targets: ["Base", "Flows", "DataLoader"]),
   ],
   dependencies: [
-    // SwiftKeychain is not yet available as a Package, so we symlink to /Sources and make it a Target
     .package(url: "https://github.com/hermanbanken/SwiftKeychain.git", from: "1.0.1"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,8 @@ let package = Package(
   targets: [
     .target(name: "Base", dependencies: ["SwiftKeychain"]),
     .target(name: "macOS", dependencies: [.target(name: "Base")]),
-    .target(name: "Flows", dependencies: [.target(name: "macOS")]),
+    .target(name: "iOS", dependencies: [.target(name: "Base")]),
+    .target(name: "Flows", dependencies: [.target(name: "macOS"), .target(name: "iOS")]),
     .target(name: "DataLoader", dependencies: [.target(name: "Flows")]),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 //
 //  Package.swift
 //  OAuth2
@@ -22,15 +22,21 @@
 import PackageDescription
 
 let package = Package(
-    name: "OAuth2",
-    dependencies: [
-        // SwiftKeychain is not yet available as a Package, so we symlink to /Sources and make it a Target
-        .package(url: "https://github.com/hermanbanken/SwiftKeychain.git", from: "1.0.1"),
-    ],
-	targets: [
-		.target(name: "Base", dependencies: ["SwiftKeychain"]),
-		.target(name: "macOS", dependencies: [.target(name: "Base")]),
-		.target(name: "Flows", dependencies: [.target(name: "macOS")]),
-		.target(name: "DataLoader", dependencies: [.target(name: "Flows")]),
-	]
+  name: "OAuth2",
+  platforms: [
+    .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
+  ],
+  products: [
+    .library(name: "OAuth2", targets: ["Base"]),
+  ],
+  dependencies: [
+    // SwiftKeychain is not yet available as a Package, so we symlink to /Sources and make it a Target
+    .package(url: "https://github.com/hermanbanken/SwiftKeychain.git", from: "1.0.1"),
+  ],
+  targets: [
+    .target(name: "Base", dependencies: ["SwiftKeychain"]),
+    .target(name: "macOS", dependencies: [.target(name: "Base")]),
+    .target(name: "Flows", dependencies: [.target(name: "macOS")]),
+    .target(name: "DataLoader", dependencies: [.target(name: "Flows")]),
+  ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
   ],
   products: [
-    .library(name: "OAuth2", targets: ["Base"]),
+    .library(name: "OAuth2", targets: ["Base", "Flows", "DataLoader"]),
   ],
   dependencies: [
     // SwiftKeychain is not yet available as a Package, so we symlink to /Sources and make it a Target

--- a/Sources/Base/OAuth2KeychainAccount.swift
+++ b/Sources/Base/OAuth2KeychainAccount.swift
@@ -19,10 +19,7 @@
 //
 
 import Foundation
-#if !NO_KEYCHAIN_IMPORT     // needs to be imported when using `swift build`, not when building via Xcode
 import SwiftKeychain
-#endif
-
 
 /**
 Keychain integration handler for OAuth2.

--- a/Sources/SwiftKeychain/Keychain.swift
+++ b/Sources/SwiftKeychain/Keychain.swift
@@ -1,1 +1,0 @@
-../../SwiftKeychain/Keychain/Keychain.swift

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -23,6 +23,7 @@ import UIKit
 import SafariServices
 #if !NO_MODULE_IMPORT
 import Base
+import Flows
 #endif
 
 

--- a/Sources/iOS/OAuth2WebViewController.swift
+++ b/Sources/iOS/OAuth2WebViewController.swift
@@ -23,6 +23,7 @@ import UIKit
 import WebKit
 #if !NO_MODULE_IMPORT
 import Base
+import Flows
 #endif
 
 


### PR DESCRIPTION
I tried to add p2/OAuth2 via Xcode 11's new SPM support. That didn't work because SwiftKeychain.

So I created this PR and https://github.com/yankodimitrov/SwiftKeychain/pull/20. Seems to work.