### PR TITLE
Fixed a memory leak related to authorizeContext

### DIFF
--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -67,7 +67,7 @@ public struct OAuth2AuthConfig {
 	/// Context information for the authorization flow:
 	/// - iOS:   The parent view controller to present from
 	/// - macOS: An NSWindow from which to present a modal sheet _or_ `nil` to present in a new window
-	public var authorizeContext: AnyObject? = nil
+	public weak var authorizeContext: AnyObject? = nil
 	
 	/// UI-specific configuration.
 	public var ui = UI()


### PR DESCRIPTION
Changed `autorizeContext` var to `weak` in order to prevent a reference cycle: `NSWindow` holding an `OAuth2CodeGrant` and at the same time being provided as it's `authorizeContext` (`authConfig.authorizeContext`).