### PR TITLE
Support 5.2.0 in Cocoapods

### DIFF
--- a/p2.OAuth2.podspec
+++ b/p2.OAuth2.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name         = 'p2.OAuth2'
-  s.version      = '5.1.0'
+  s.version      = '5.2.0'
   s.summary      = 'OAuth2 framework for macOS, iOS and tvOS, written in Swift.'
   s.description  = <<-DESC
                    OAuth2 frameworks for macOS, iOS and tvOS written in Swift.


### PR DESCRIPTION
Updated the OAuth2 version number in the podspec to allow using version 5.2.0 with Cocoapods