### PR TITLE
#350 Fix debug logging in WebViewController

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ import PackageDescription
 let package = Package(
 	name: "OAuth2",
 	platforms: [
-		.macOS(.v10_11), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
+		.macOS(.v10_11), .iOS(.v9), .tvOS(.v9), .watchOS(.v3)
 	],
 	products: [
 		.library(name: "OAuth2", targets: ["Base", "Flows", "DataLoader"]),


### PR DESCRIPTION
Updated the iOS deployment target to 9.0+ to silence the warning in Xcode 12