### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ func application(_ app: UIApplication,
 }
 ```
 
+For iOS 13 make the callback in `SceneDelegate.swift`
+
+```swift
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+	oauth2?.handleRedirectURL(url)
+}
+```
+
 You’re all set!
 
 ---

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ For iOS 13 make the callback in `SceneDelegate.swift`
 
 ```swift
 func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-	oauth2?.handleRedirectURL(url)
+	if let url = URLContexts.first?.url {
+		AppDelegate.shared.oauth2?.handleRedirectURL(url)
+	}
 }
 ```
 


### PR DESCRIPTION
`func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {...}` is not called in fresh iOS 13 / Xcode 12 apps. Instead I had to use the new `SceneDelegate` method. Took me hours to track down this problem. 🙄 
https://stackoverflow.com/questions/58624786/method-applicationopenurloptions-is-not-called