### PR TITLE
Fix issue starting`ASWebAuthenticationSession` on iOS 13+

### DIFF
--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -152,8 +152,16 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 		return (authenticationSession as! ASWebAuthenticationSession).start()
 #else
 		if #available(iOS 12, *) {
-			authenticationSession = ASWebAuthenticationSession(url: url, callbackURLScheme: redirect, completionHandler: completionHandler)
-			return (authenticationSession as! ASWebAuthenticationSession).start()
+            let webAuthenticationSession = ASWebAuthenticationSession(url: url, callbackURLScheme: redirect, completionHandler: completionHandler)
+            
+            if #available(iOS 13, *) {
+                if let presentationContextProvider = self.oauth2.authConfig.authorizeContext as? ASWebAuthenticationPresentationContextProviding {
+                    webAuthenticationSession.presentationContextProvider = presentationContextProvider
+                }
+            }
+            
+			authenticationSession = webAuthenticationSession
+			return webAuthenticationSession.start()
 		} else {
 			authenticationSession = SFAuthenticationSession(url: url, callbackURLScheme: redirect, completionHandler: completionHandler)
 			return (authenticationSession as! SFAuthenticationSession).start()
@@ -274,7 +282,6 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 		return web
 	}
 }
-
 
 /**
 A custom `SFSafariViewControllerDelegate` that we use with the safari view controller.

--- a/Sources/iOS/UIViewController+ASWebAuthenticationPresentationContextProviding.swift
+++ b/Sources/iOS/UIViewController+ASWebAuthenticationPresentationContextProviding.swift
@@ -1,0 +1,36 @@
+//
+//  OAuth2WebViewController.swift
+//  OAuth2
+//
+//  Created by Christian Gossain on 12/31/20.
+//  Copyright 2014 Pascal Pfiffner
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+#if os(iOS)
+
+import AuthenticationServices
+#if !NO_MODULE_IMPORT
+import Base
+#endif
+
+// This extension provides a global default implementation of the `ASWebAuthenticationPresentationContextProviding` which
+// is required to use `ASWebAuthenticationSession`.
+extension UIViewController: ASWebAuthenticationPresentationContextProviding {
+    @available(iOS 13.0, *)
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return view.window!
+    }
+}
+
+#endif


### PR DESCRIPTION
Starting the `ASWebAuthenticationSession` on iOS 13 was triggering an error. Upon further investigation, it appears Apple has added a new protocol/property to `ASWebAuthenticationSession` called `presentationContextProvider` which is required to start the session.

This commit fixes the issue by providing a default implementation of the `ASWebAuthenticationPresentationContextProviding` protocol on all view controllers, and setting the `presentationContextProvider` property to the `authorizeContext`.