### PR TITLE
Fix implementation of `ASWebAuthenticationPresentationContextProviding` protocol

### DIFF
--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -314,11 +314,11 @@ class OAuth2ASWebAuthenticationPresentationContextProvider: NSObject, ASWebAuthe
 	}
 
 	public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-		guard let context = authorizer.oauth2.authConfig.authorizeContext as? ASPresentationAnchor else {
-			fatalError("Invalid authConfig.authorizeContext, must be ASPresentationAnchor but is \(String(describing: authorizer.oauth2.authConfig.authorizeContext))")
+		guard let context = authorizer.oauth2.authConfig.authorizeContext as? UIViewController else {
+			fatalError("Invalid authConfig.authorizeContext, must be a UIViewController but is \(String(describing: authorizer.oauth2.authConfig.authorizeContext))")
 		}
 
-		return context
+		return context.view.window!
 	}
 }
 

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -150,7 +150,17 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 					self.oauth2.logger?.warn("OAuth2", msg: "Cannot intercept redirect URL: \(err)")
 				}
 			} else {
-				self.oauth2.didFail(with: error?.asOAuth2Error)
+				if let authenticationSessionError = error as? ASWebAuthenticationSessionError {
+					switch authenticationSessionError.code {
+					case .canceledLogin:
+						self.oauth2.didFail(with: .requestCancelled)
+					default:
+						self.oauth2.didFail(with: error?.asOAuth2Error)
+					}
+				}
+				else {
+					self.oauth2.didFail(with: error?.asOAuth2Error)
+				}
 			}
 			self.authenticationSession = nil
 			self.webAuthenticationPresentationContextProvider = nil


### PR DESCRIPTION
This protocol expects an ASPresentationAnchor to be returned (which is a UIWindow on iOS, or NSWindow on Mac OS). This commit updates the implementation to return the window object associated with the view of the `authorizeContext` (and assumes the authorize context is an instance of UIViewController).

This change is in line with Apple’s example documentation:
https://developer.apple.com/documentation/authenticationservices/authenticating_a_user_through_a_web_service