### PR TITLE
Change type of authorize context to ASPresentationAnchor

### DIFF
--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -328,11 +328,15 @@ class OAuth2ASWebAuthenticationPresentationContextProvider: NSObject, ASWebAuthe
 	}
 
 	public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-		guard let context = authorizer.oauth2.authConfig.authorizeContext as? UIViewController else {
-			fatalError("Invalid authConfig.authorizeContext, must be a UIViewController but is \(String(describing: authorizer.oauth2.authConfig.authorizeContext))")
-		}
+        if let context = authorizer.oauth2.authConfig.authorizeContext as? ASPresentationAnchor {
+            return context
+        }
 
-		return context.view.window!
+        if let context = authorizer.oauth2.authConfig.authorizeContext as? UIViewController {
+            return context.view.window!
+        }
+
+        fatalError("Invalid authConfig.authorizeContext, must be an ASPresentationAnchor but is \(String(describing: authorizer.oauth2.authConfig.authorizeContext))")
 	}
 }
 


### PR DESCRIPTION
The type of the presentation anchor for the `ASWebAuthenticationSession` needs to be an `ASPresentationAnchor` to work with SwiftUI. The change was introduced in 5.3.1, version 5.3.0 worked perfectly fine with SwiftUI.

In a pure SwiftUI app it's not easy (is it even possible?) to get a reference for a `UIWindow`.

With this change it's possible to provide an `ASPresentationAnchor` in SwiftUI like:
```swift
let presentationAnchor = ASPresentationAnchor()

oauth2.authConfig.authorizeContext = anchor
```

UIKit applications can provide a reference to a `UIWindow` since the [`ASPresentationAnchor`](https://developer.apple.com/documentation/authenticationservices/aspresentationanchor) is a typealias of the `UIWindow`. So instead of getting the `UIWindow` reference from a `UIViewController`, provide a reference to a `UIWindow` directly to the `authorizeContext`.