### PR TITLE
Issue #359: Access to ASWebAuthenticationSession-prefersEphemeralWebBrowserSession

### DIFF
--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -46,6 +46,9 @@ public struct OAuth2AuthConfig {
 		/// Starting with iOS 12, `ASWebAuthenticationSession` can be used for embedded authorization instead of our custom class. You can turn this on here.
 		public var useAuthenticationSession = false
 		
+		/// May be passed through to [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio).
+		public var prefersEphemeralWebBrowserSession = false
+		
 		#if os(iOS)
 		/// By assigning your own style you can configure how the embedded authorization is presented.
 		public var modalPresentationStyle = UIModalPresentationStyle.fullScreen


### PR DESCRIPTION
This property has been introduced in iOS 13 (https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio?language=objc)

and we would like to set it to true in our project. This pull requests make it accessible.