### PR TITLE
Fixes #373

### DIFF
--- a/Sources/Base/OAuth2AuthorizerUI.swift
+++ b/Sources/Base/OAuth2AuthorizerUI.swift
@@ -35,6 +35,7 @@ public protocol OAuth2AuthorizerUI {
 	- parameter url: The authorize URL to open
 	- throws:        UnableToOpenAuthorizeURL on failure
 	*/
+    @available(iOSApplicationExtension, unavailable)
 	func openAuthorizeURLInBrowser(_ url: URL) throws
 	
 	/**


### PR DESCRIPTION
This pull request fixes the build for Xcode 13 Beta 3 by adding the `@available(iOSApplicationExtension, unavailable)` attribute to the `openAuthorizeURLInBrowser` method.