### PR TITLE
Implement optional custom User-Agent string for embedded MacOS mode

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@ Contributors
 
 Contributors to the codebase, in reverse chronological order:
 
+- Greg Price, @ObscureBug
 - James Addyman, @james-rantmedia
 - Foti Dim, @fotidim
 - Denis, @telipskiy

--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ Similar is how you specify custom HTTP headers:
     // or in your settings:
     "headers": ["Accept": "application/json, text/plain"]
 
+Some sites (e.g. Slack) validate the User-Agent string against supported browser versions, which may not match WebKit's default in embedded mode. The embedded mode User-Agent may be overriden with:
+
+    oauth2.customUserAgent = "Version/15.6.1 Safari"
+    // or in your settings:
+    "custom_user_agent": "Your string of choice"
+
 Starting with version 2.0.1 on iOS 9, `SFSafariViewController` will be used for embedded authorization.
 Starting after version 4.2, on iOS 11 (`SFAuthenticationSession`) and iOS 12 (`ASWebAuthenticationSession`), you can opt-in to these newer authorization session view controllers:
 

--- a/Sources/Base/OAuth2Base.swift
+++ b/Sources/Base/OAuth2Base.swift
@@ -120,6 +120,12 @@ open class OAuth2Base: OAuth2Securable {
 		get { return clientConfig.customParameters }
 		set { clientConfig.customParameters = newValue }
 	}
+
+	/// The optional User-Agent string to use for embedded mode.
+	public final var customUserAgent: String? {
+		get { return clientConfig.customUserAgent }
+		set { clientConfig.customUserAgent = newValue }
+	}
 	
 	
 	/// This closure is internally used with `authorize(params:callback:)` and only exposed for subclassing reason, do not mess with it!
@@ -158,7 +164,8 @@ open class OAuth2Base: OAuth2Securable {
 	- refresh_uri (URL-String), if omitted the token_uri will be used to obtain tokens
 	- redirect_uris (Array of URL-Strings)
 	- scope (String)
-	
+	- custom_user_agent (String)
+
 	- client_name (String)
 	- registration_uri (URL-String)
 	- logo_uri (URL-String)

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -96,6 +96,9 @@ open class OAuth2ClientConfig {
 	///
 	open var useProofKeyForCodeExchange = false
 
+	/// Optional custom User-Agent string for embedded mode.
+	open var customUserAgent: String?
+
 	/**
 	Initializer to initialize properties from a settings dictionary.
 	*/
@@ -156,6 +159,7 @@ open class OAuth2ClientConfig {
 			useProofKeyForCodeExchange = usePKCE
 		}
 		
+		customUserAgent = settings["custom_user_agent"] as? String
 	}
 	
 	

--- a/Sources/macOS/OAuth2WebViewController+macOS.swift
+++ b/Sources/macOS/OAuth2WebViewController+macOS.swift
@@ -125,6 +125,7 @@ public class OAuth2WebViewController: NSViewController, WKNavigationDelegate, NS
 		web.translatesAutoresizingMaskIntoConstraints = false
 		web.navigationDelegate = self
 		web.alphaValue = 0.0
+		web.customUserAgent = oauth?.customUserAgent
 		webView = web
 		
 		view.addSubview(web)


### PR DESCRIPTION
Some sites (e.g. Slack) validate the User-Agent string against their supported browser versions.  While Safari is based on WebKit, the User-Agent string sent by WebKit is a sub-set of Safari's.  When sites (like Slack) don't include the matching WebKit's specific User-Agent in their authentication logic, they reject the connection attempt with "Unsupported browser".

In this specific case, Slack said to override the User-Agent, so here we are.

This situation occurs for embedded mode on MacOS.  The change adds an optional configuration parameter that uses the WkWebView API to override the default as follows:

```
oauth2.customUserAgent = "Version/15.6.1 Safari"
// or in your settings:
"custom_user_agent": "Your string of choice"
```