### PR TITLE
fixed issue with wrong state-machine after pull down gesture on presented SFSafariViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 Version numbering represents the Swift version, plus a running number representing updates, fixes and new features at the same time.
 You can also refer to commit logs to get details on what was implemented, fixed and improved.
 
+#### 5.3.3
+
+- Fixed issue with wrong states on dismiss via pull down gesture.
+
 #### 5.3.2
 
 - Fix tvOS build.

--- a/OAuth2.xcodeproj/project.pbxproj
+++ b/OAuth2.xcodeproj/project.pbxproj
@@ -826,7 +826,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 5.3.2;
+				MARKETING_VERSION = 5.3.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_SWIFT_FLAGS = "-DNO_KEYCHAIN_IMPORT -DNO_MODULE_IMPORT";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.p2.OAuth2;
@@ -854,7 +854,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 5.3.2;
+				MARKETING_VERSION = 5.3.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_SWIFT_FLAGS = "-DNO_KEYCHAIN_IMPORT -DNO_MODULE_IMPORT";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.p2.OAuth2;
@@ -997,7 +997,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 5.3.2;
+				MARKETING_VERSION = 5.3.3;
 				OTHER_SWIFT_FLAGS = "-DNO_KEYCHAIN_IMPORT -DNO_MODULE_IMPORT";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.p2.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = OAuth2;
@@ -1020,7 +1020,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 5.3.2;
+				MARKETING_VERSION = 5.3.3;
 				OTHER_SWIFT_FLAGS = "-DNO_KEYCHAIN_IMPORT -DNO_MODULE_IMPORT";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.p2.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = OAuth2;
@@ -1043,7 +1043,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MARKETING_VERSION = 5.3.2;
+				MARKETING_VERSION = 5.3.3;
 				OTHER_SWIFT_FLAGS = "-DNO_KEYCHAIN_IMPORT -DNO_MODULE_IMPORT";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.p2.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = OAuth2;
@@ -1067,7 +1067,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MARKETING_VERSION = 5.3.2;
+				MARKETING_VERSION = 5.3.3;
 				OTHER_SWIFT_FLAGS = "-DNO_KEYCHAIN_IMPORT -DNO_MODULE_IMPORT";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.p2.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = OAuth2;

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -37,8 +37,8 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	/// The OAuth2 instance this authorizer belongs to.
 	public unowned let oauth2: OAuth2Base
 	
-	/// Used to store the `SFSafariViewControllerDelegate`.
-	private var safariViewDelegate: AnyObject?
+	/// Used to store the `SFSafariViewControllerDelegate` || `UIAdaptivePresentationControllerDelegate`
+	private var safariViewDelegate: OAuth2SFViewControllerDelegate?
 	
 	/// Used to store the authentication session.
 	private var authenticationSession: AnyObject?
@@ -205,7 +205,7 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 		safariViewDelegate = OAuth2SFViewControllerDelegate(authorizer: self)
 		let web = SFSafariViewController(url: url)
 		web.title = oauth2.authConfig.ui.title
-		web.delegate = safariViewDelegate as! OAuth2SFViewControllerDelegate
+		web.delegate = safariViewDelegate
 		if let barTint = oauth2.authConfig.ui.barTintColor {
 			web.preferredBarTintColor = barTint
 		}
@@ -216,7 +216,7 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 		
 		willPresent(viewController: web, in: nil)
 		controller.present(web, animated: true, completion: nil)
-		
+		web.presentationController?.delegate = safariViewDelegate
 		return web
 	}
 	
@@ -299,9 +299,9 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 /**
 A custom `SFSafariViewControllerDelegate` that we use with the safari view controller.
 */
-class OAuth2SFViewControllerDelegate: NSObject, SFSafariViewControllerDelegate {
+class OAuth2SFViewControllerDelegate: NSObject, SFSafariViewControllerDelegate, UIAdaptivePresentationControllerDelegate {
 	
-	let authorizer: OAuth2Authorizer
+	weak var authorizer: OAuth2Authorizer?
 	
 	init(authorizer: OAuth2Authorizer) {
 		self.authorizer = authorizer
@@ -309,7 +309,13 @@ class OAuth2SFViewControllerDelegate: NSObject, SFSafariViewControllerDelegate {
 	
 	@available(iOS 9.0, *)
 	func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-		authorizer.safariViewControllerDidCancel(controller)
+		authorizer?.safariViewControllerDidCancel(controller)
+	}
+
+	// called in case ViewController is dismissed via pulling down the presented sheet.
+	func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
+		guard let safariViewController = presentationController.presentedViewController as? SFSafariViewController else { return }
+		authorizer?.safariViewControllerDidCancel(safariViewController)
 	}
 }
 

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -312,11 +312,11 @@ class OAuth2SFViewControllerDelegate: NSObject, SFSafariViewControllerDelegate, 
 		authorizer?.safariViewControllerDidCancel(controller)
 	}
 
-	// called in case ViewController is dismissed via pulling down the presented sheet.
-	func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
-		guard let safariViewController = presentationController.presentedViewController as? SFSafariViewController else { return }
-		authorizer?.safariViewControllerDidCancel(safariViewController)
-	}
+    // called in case ViewController is dismissed via pulling down the presented sheet.
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        guard let safariViewController = presentationController.presentedViewController as? SFSafariViewController else { return }
+        authorizer?.safariViewControllerDidCancel(safariViewController)
+    }
 }
 
 @available(iOS 13.0, *)


### PR DESCRIPTION
In case the SFSafariViewController is presented modally, it can be dismissed via pull down gesture. In that case the state machine is completely broken. Therefore I added the presentationDelegate, which ensures that the same logic is triggered as in case the "Finished" button is pressed with this interaction.