### PR TITLE
Update OAuth2Authorizer+iOS.swift

### DIFF
--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -167,12 +167,8 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 			self.webAuthenticationPresentationContextProvider = nil
 		}
 		
-		#if targetEnvironment(macCatalyst)
 		authenticationSession = ASWebAuthenticationSession(url: url, callbackURLScheme: redirectURL.scheme, completionHandler: completionHandler)
-		return (authenticationSession as! ASWebAuthenticationSession).start()
-		#else
-		authenticationSession = ASWebAuthenticationSession(url: url, callbackURLScheme: redirectURL.scheme, completionHandler: completionHandler)
-		if #available(iOS 13.0, *) {
+		if #available(iOS 13.0, macCatalyst 13.1, *) {
 			webAuthenticationPresentationContextProvider = OAuth2ASWebAuthenticationPresentationContextProvider(authorizer: self)
 			if let session = authenticationSession as? ASWebAuthenticationSession {
 				session.presentationContextProvider = webAuthenticationPresentationContextProvider as! OAuth2ASWebAuthenticationPresentationContextProvider
@@ -180,7 +176,6 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 			}
 		}
 		return (authenticationSession as! ASWebAuthenticationSession).start()
-		#endif
 	}
 	
 	


### PR DESCRIPTION
Update OAuth2Authorizer+iOS.swift
macCatalyst 13.1 need setting presentationContextProvider. If not will get an error: 
```
Printing description of error:
▿ Optional<Error>
  - some : Error Domain=com.apple.AuthenticationServices.WebAuthenticationSession Code=2 "Cannot start ASWebAuthenticationSession without providing presentation context. Set presentationContextProvider before calling -start." UserInfo={NSDebugDescription=Cannot start ASWebAuthenticationSession without providing presentation context. Set presentationContextProvider before calling -start.}
```