### PR TITLE
Added requestUsingIDToken configuration

### DIFF
--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -72,6 +72,9 @@ public struct OAuth2AuthConfig {
 	/// - macOS: An NSWindow from which to present a modal sheet _or_ `nil` to present in a new window
 	public weak var authorizeContext: AnyObject? = nil
 	
+	/// Whether to use the `id_token` instead of the `access_token` for signed requests
+	public var requestUsingIDToken = false
+	
 	/// UI-specific configuration.
 	public var ui = UI()
 }

--- a/Sources/Base/extensions.swift
+++ b/Sources/Base/extensions.swift
@@ -93,10 +93,17 @@ extension URLRequest {
 	- parameter oauth2: The OAuth2 instance providing the access token to sign the request
 	*/
 	public mutating func sign(with oauth2: OAuth2Base) throws {
-		guard let access = oauth2.clientConfig.accessToken, !access.isEmpty else {
-			throw OAuth2Error.noAccessToken
+		if oauth2.authConfig.requestUsingIDToken {
+			guard let idToken = oauth2.clientConfig.idToken, !idToken.isEmpty else {
+				throw OAuth2Error.noAccessToken
+			}
+			setValue("Bearer \(idToken)", forHTTPHeaderField: "Authorization")
+		} else {
+			guard let access = oauth2.clientConfig.accessToken, !access.isEmpty else {
+				throw OAuth2Error.noAccessToken
+			}
+			setValue("Bearer \(access)", forHTTPHeaderField: "Authorization")
 		}
-		setValue("Bearer \(access)", forHTTPHeaderField: "Authorization")
 	}
 	
 	/**


### PR DESCRIPTION
Fixes #405 as it allows the use of the `id_token` instead of the `access_toekn` when signing requests.
This is handy when using AWS Cognito with AWS API Gateway.