### PR TITLE
Adds visionOS support.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@ Contributors
 
 Contributors to the codebase, in reverse chronological order:
 
+- Joseph Quigley, @josephquigley
 - Martin Pittenauer, @m4p
 - Lars, @longinius
 - Christian Gossain, @cgossain

--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -36,15 +36,23 @@ public struct OAuth2AuthConfig {
 		
 		/// By assigning your own UIBarButtonItem (!) you can override the back button that is shown in the iOS embedded web view (does NOT apply to `SFSafariViewController`).
 		public var backButton: AnyObject? = nil
+        
+        /// If true it makes the login cancellable, otherwise the cancel button is not shown in the embedded web view.
+        public var showCancelButton = true
 		
-		/// If true it makes the login cancellable, otherwise the cancel button is not shown in the embedded web view.
-		public var showCancelButton = true
-		
+        #if os(visionOS) // Must come first per Apple documentation
 		/// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
-		public var useSafariView = true
+		public var useSafariView = false
 		
 		/// Starting with iOS 12, `ASWebAuthenticationSession` can be used for embedded authorization instead of our custom class. You can turn this on here.
-		public var useAuthenticationSession = false
+		public var useAuthenticationSession = true
+        #else
+        /// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
+        public var useSafariView = true
+        
+        /// Starting with iOS 12, `ASWebAuthenticationSession` can be used for embedded authorization instead of our custom class. You can turn this on here.
+        public var useAuthenticationSession = false
+        #endif
 		
 		/// May be passed through to [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio).
 		public var prefersEphemeralWebBrowserSession = false

--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -36,23 +36,23 @@ public struct OAuth2AuthConfig {
 		
 		/// By assigning your own UIBarButtonItem (!) you can override the back button that is shown in the iOS embedded web view (does NOT apply to `SFSafariViewController`).
 		public var backButton: AnyObject? = nil
-        
-        /// If true it makes the login cancellable, otherwise the cancel button is not shown in the embedded web view.
-        public var showCancelButton = true
 		
-        #if os(visionOS) // Must come first per Apple documentation
+		/// If true it makes the login cancellable, otherwise the cancel button is not shown in the embedded web view.
+		public var showCancelButton = true
+		
+		#if os(visionOS) // Must come first per Apple documentation
 		/// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
 		public var useSafariView = false
 		
 		/// Starting with iOS 12, `ASWebAuthenticationSession` can be used for embedded authorization instead of our custom class. You can turn this on here.
 		public var useAuthenticationSession = true
-        #else
-        /// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
-        public var useSafariView = true
-        
-        /// Starting with iOS 12, `ASWebAuthenticationSession` can be used for embedded authorization instead of our custom class. You can turn this on here.
-        public var useAuthenticationSession = false
-        #endif
+		#else
+		/// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
+		public var useSafariView = true
+		
+		/// Starting with iOS 12, `ASWebAuthenticationSession` can be used for embedded authorization instead of our custom class. You can turn this on here.
+		public var useAuthenticationSession = false
+		#endif
 		
 		/// May be passed through to [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio).
 		public var prefersEphemeralWebBrowserSession = false

--- a/Sources/Base/OAuth2AuthorizerUI.swift
+++ b/Sources/Base/OAuth2AuthorizerUI.swift
@@ -29,6 +29,8 @@ public protocol OAuth2AuthorizerUI {
 	/// The OAuth2 instance this authorizer belongs to.
 	var oauth2: OAuth2Base { get }
 	
+    #if os(visionOS) // Intentionally blank per Apple documentation
+    #elseif os(iOS)
 	/**
 	Open the authorize URL in the OS browser.
 	
@@ -36,6 +38,7 @@ public protocol OAuth2AuthorizerUI {
 	- throws:        UnableToOpenAuthorizeURL on failure
 	*/
 	func openAuthorizeURLInBrowser(_ url: URL) throws
+    #endif
 	
 	/**
 	Tries to use the given context to present the authorization screen. Context could be a UIViewController for iOS or an NSWindow on macOS.

--- a/Sources/Base/OAuth2AuthorizerUI.swift
+++ b/Sources/Base/OAuth2AuthorizerUI.swift
@@ -29,8 +29,8 @@ public protocol OAuth2AuthorizerUI {
 	/// The OAuth2 instance this authorizer belongs to.
 	var oauth2: OAuth2Base { get }
 	
-    #if os(visionOS) // Intentionally blank per Apple documentation
-    #elseif os(iOS)
+	#if os(visionOS) // Intentionally blank per Apple documentation
+	#elseif os(iOS)
 	/**
 	Open the authorize URL in the OS browser.
 	
@@ -38,7 +38,7 @@ public protocol OAuth2AuthorizerUI {
 	- throws:        UnableToOpenAuthorizeURL on failure
 	*/
 	func openAuthorizeURLInBrowser(_ url: URL) throws
-    #endif
+	#endif
 	
 	/**
 	Tries to use the given context to present the authorization screen. Context could be a UIViewController for iOS or an NSWindow on macOS.

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -98,7 +98,7 @@ open class OAuth2: OAuth2Base {
 	
 	- parameter params:   Optional key/value pairs to pass during authorization and token refresh
 	- parameter callback: The callback to call when authorization finishes (parameters will be non-nil but may be an empty dict), fails or
-                      is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
+	                      is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
 	*/
 	public final func authorize(params: OAuth2StringDict? = nil, callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
 		if isAuthorizing {
@@ -142,7 +142,7 @@ open class OAuth2: OAuth2Base {
 	- parameter from:     The context to start authorization from, depends on platform (UIViewController or NSWindow, see `authorizeContext`)
 	- parameter params:   Optional key/value pairs to pass during authorization
 	- parameter callback: The callback to call when authorization finishes (parameters will be non-nil but may be an empty dict), fails or
-                      is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
+	                      is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
 	*/
 	open func authorizeEmbedded(from context: AnyObject, params: OAuth2StringDict? = nil, callback: @escaping ((_ authParameters: OAuth2JSON?, _ error: OAuth2Error?) -> Void)) {
 		if isAuthorizing {		// `authorize()` will check this, but we want to exit before changing `authConfig`
@@ -181,7 +181,7 @@ open class OAuth2: OAuth2Base {
 	
 	- parameter params:   Optional key/value pairs to pass during authorization
 	- parameter callback: The callback to call once the client knows whether it has an access token or not; if `success` is true an
-                      access token is present
+	                      access token is present
 	*/
 	open func tryToObtainAccessTokenIfNeeded(params: OAuth2StringDict? = nil, callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
 		if hasUnexpiredAccessToken() {
@@ -268,7 +268,7 @@ open class OAuth2: OAuth2Base {
 	Method that creates the OAuth2AuthRequest instance used to create the authorize URL
 	
 	- parameter redirect: The redirect URI string to supply. If it is nil, the first value of the settings' `redirect_uris` entries is
-                      used. Must be present in the end!
+	                      used. Must be present in the end!
 	- parameter scope:    The scope to request
 	- parameter params:   Any additional parameters as dictionary with string keys and values that will be added to the query part
 	- returns:            OAuth2AuthRequest to be used to call to the authorize endpoint
@@ -318,7 +318,7 @@ open class OAuth2: OAuth2Base {
 	Convenience method to be overridden by and used from subclasses.
 	
 	- parameter redirect: The redirect URI string to supply. If it is nil, the first value of the settings' `redirect_uris` entries is
-                      used. Must be present in the end!
+	                      used. Must be present in the end!
 	- parameter scope:    The scope to request
 	- parameter params:   Any additional parameters as dictionary with string keys and values that will be added to the query part
 	- returns:            NSURL to be used to start the OAuth dance
@@ -412,7 +412,7 @@ open class OAuth2: OAuth2Base {
 	If both are nil, instantiates a blank `OAuth2DynReg` instead, then attempts client registration.
 	
 	- parameter callback: The callback to call on the main thread; if both json and error is nil no registration was attempted; error is nil
-                      on success
+	                      on success
 	*/
 	public func registerClientIfNeeded(callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
 		if nil != clientId || !type(of: self).clientIdMandatory {

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -23,7 +23,7 @@ import Foundation
  import Base
  #if os(macOS)
   import macOS
- #elseif os(iOS)
+ #elseif os(iOS) || os(visionOS)
   import iOS
  #elseif os(tvOS)
   import tvOS

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -98,7 +98,7 @@ open class OAuth2: OAuth2Base {
 	
 	- parameter params:   Optional key/value pairs to pass during authorization and token refresh
 	- parameter callback: The callback to call when authorization finishes (parameters will be non-nil but may be an empty dict), fails or
-	                      is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
+						  is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
 	*/
 	public final func authorize(params: OAuth2StringDict? = nil, callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
 		if isAuthorizing {
@@ -142,7 +142,7 @@ open class OAuth2: OAuth2Base {
 	- parameter from:     The context to start authorization from, depends on platform (UIViewController or NSWindow, see `authorizeContext`)
 	- parameter params:   Optional key/value pairs to pass during authorization
 	- parameter callback: The callback to call when authorization finishes (parameters will be non-nil but may be an empty dict), fails or
-	                      is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
+						  is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
 	*/
 	open func authorizeEmbedded(from context: AnyObject, params: OAuth2StringDict? = nil, callback: @escaping ((_ authParameters: OAuth2JSON?, _ error: OAuth2Error?) -> Void)) {
 		if isAuthorizing {		// `authorize()` will check this, but we want to exit before changing `authConfig`
@@ -181,7 +181,7 @@ open class OAuth2: OAuth2Base {
 	
 	- parameter params:   Optional key/value pairs to pass during authorization
 	- parameter callback: The callback to call once the client knows whether it has an access token or not; if `success` is true an
-	                      access token is present
+						  access token is present
 	*/
 	open func tryToObtainAccessTokenIfNeeded(params: OAuth2StringDict? = nil, callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
 		if hasUnexpiredAccessToken() {
@@ -220,21 +220,21 @@ open class OAuth2: OAuth2Base {
 	- parameter params: Optional key/value pairs to pass during authorization
 	*/
 	open func doAuthorize(params: OAuth2StringDict? = nil) throws {
-        #if os(visionOS) // Must come first per Apple documentation
+		#if os(visionOS) // Must come first per Apple documentation
 //        authorizer.authenticationSessionEmbedded
-        try doAuthorizeEmbedded(with: authConfig, params: params)
-        #elseif os(iOS)
+		try doAuthorizeEmbedded(with: authConfig, params: params)
+		#elseif os(iOS)
 		if authConfig.authorizeEmbedded {
 			try doAuthorizeEmbedded(with: authConfig, params: params)
 		}
 		else {
 			try doOpenAuthorizeURLInBrowser(params: params)
 		}
-        #endif
+		#endif
 	}
 	
-    #if os(visionOS) // Intentionally blank per Apple documentation
-    #elseif os(iOS)
+	#if os(visionOS) // Intentionally blank per Apple documentation
+	#elseif os(iOS)
 	/**
 	Open the authorize URL in the OS's browser. Forwards to the receiver's `authorizer`, which is a platform-dependent implementation of
 	`OAuth2AuthorizerUI`.
@@ -247,7 +247,7 @@ open class OAuth2: OAuth2Base {
 		logger?.debug("OAuth2", msg: "Opening authorize URL in system browser: \(url)")
 		try authorizer.openAuthorizeURLInBrowser(url)
 	}
-    #endif
+	#endif
 	
 	/**
 	Tries to use the current auth config context, which on iOS should be a UIViewController and on OS X a NSViewController, to present the
@@ -269,7 +269,7 @@ open class OAuth2: OAuth2Base {
 	Method that creates the OAuth2AuthRequest instance used to create the authorize URL
 	
 	- parameter redirect: The redirect URI string to supply. If it is nil, the first value of the settings' `redirect_uris` entries is
-	                      used. Must be present in the end!
+						  used. Must be present in the end!
 	- parameter scope:    The scope to request
 	- parameter params:   Any additional parameters as dictionary with string keys and values that will be added to the query part
 	- returns:            OAuth2AuthRequest to be used to call to the authorize endpoint
@@ -319,7 +319,7 @@ open class OAuth2: OAuth2Base {
 	Convenience method to be overridden by and used from subclasses.
 	
 	- parameter redirect: The redirect URI string to supply. If it is nil, the first value of the settings' `redirect_uris` entries is
-	                      used. Must be present in the end!
+						  used. Must be present in the end!
 	- parameter scope:    The scope to request
 	- parameter params:   Any additional parameters as dictionary with string keys and values that will be added to the query part
 	- returns:            NSURL to be used to start the OAuth dance
@@ -413,7 +413,7 @@ open class OAuth2: OAuth2Base {
 	If both are nil, instantiates a blank `OAuth2DynReg` instead, then attempts client registration.
 	
 	- parameter callback: The callback to call on the main thread; if both json and error is nil no registration was attempted; error is nil
-	                      on success
+						  on success
 	*/
 	public func registerClientIfNeeded(callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
 		if nil != clientId || !type(of: self).clientIdMandatory {

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -221,7 +221,6 @@ open class OAuth2: OAuth2Base {
 	*/
 	open func doAuthorize(params: OAuth2StringDict? = nil) throws {
 		#if os(visionOS) // Must come first per Apple documentation
-//        authorizer.authenticationSessionEmbedded
 		try doAuthorizeEmbedded(with: authConfig, params: params)
 		#elseif os(iOS)
 		if authConfig.authorizeEmbedded {

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -98,7 +98,7 @@ open class OAuth2: OAuth2Base {
 	
 	- parameter params:   Optional key/value pairs to pass during authorization and token refresh
 	- parameter callback: The callback to call when authorization finishes (parameters will be non-nil but may be an empty dict), fails or
-						  is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
+                      is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
 	*/
 	public final func authorize(params: OAuth2StringDict? = nil, callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
 		if isAuthorizing {
@@ -142,7 +142,7 @@ open class OAuth2: OAuth2Base {
 	- parameter from:     The context to start authorization from, depends on platform (UIViewController or NSWindow, see `authorizeContext`)
 	- parameter params:   Optional key/value pairs to pass during authorization
 	- parameter callback: The callback to call when authorization finishes (parameters will be non-nil but may be an empty dict), fails or
-						  is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
+                      is canceled (error will be non-nil, e.g. `.requestCancelled` if auth was aborted)
 	*/
 	open func authorizeEmbedded(from context: AnyObject, params: OAuth2StringDict? = nil, callback: @escaping ((_ authParameters: OAuth2JSON?, _ error: OAuth2Error?) -> Void)) {
 		if isAuthorizing {		// `authorize()` will check this, but we want to exit before changing `authConfig`
@@ -181,7 +181,7 @@ open class OAuth2: OAuth2Base {
 	
 	- parameter params:   Optional key/value pairs to pass during authorization
 	- parameter callback: The callback to call once the client knows whether it has an access token or not; if `success` is true an
-						  access token is present
+                      access token is present
 	*/
 	open func tryToObtainAccessTokenIfNeeded(params: OAuth2StringDict? = nil, callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
 		if hasUnexpiredAccessToken() {
@@ -269,7 +269,7 @@ open class OAuth2: OAuth2Base {
 	Method that creates the OAuth2AuthRequest instance used to create the authorize URL
 	
 	- parameter redirect: The redirect URI string to supply. If it is nil, the first value of the settings' `redirect_uris` entries is
-						  used. Must be present in the end!
+                      used. Must be present in the end!
 	- parameter scope:    The scope to request
 	- parameter params:   Any additional parameters as dictionary with string keys and values that will be added to the query part
 	- returns:            OAuth2AuthRequest to be used to call to the authorize endpoint
@@ -319,7 +319,7 @@ open class OAuth2: OAuth2Base {
 	Convenience method to be overridden by and used from subclasses.
 	
 	- parameter redirect: The redirect URI string to supply. If it is nil, the first value of the settings' `redirect_uris` entries is
-						  used. Must be present in the end!
+                      used. Must be present in the end!
 	- parameter scope:    The scope to request
 	- parameter params:   Any additional parameters as dictionary with string keys and values that will be added to the query part
 	- returns:            NSURL to be used to start the OAuth dance
@@ -413,7 +413,7 @@ open class OAuth2: OAuth2Base {
 	If both are nil, instantiates a blank `OAuth2DynReg` instead, then attempts client registration.
 	
 	- parameter callback: The callback to call on the main thread; if both json and error is nil no registration was attempted; error is nil
-						  on success
+                      on success
 	*/
 	public func registerClientIfNeeded(callback: @escaping ((OAuth2JSON?, OAuth2Error?) -> Void)) {
 		if nil != clientId || !type(of: self).clientIdMandatory {

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -220,14 +220,21 @@ open class OAuth2: OAuth2Base {
 	- parameter params: Optional key/value pairs to pass during authorization
 	*/
 	open func doAuthorize(params: OAuth2StringDict? = nil) throws {
+        #if os(visionOS) // Must come first per Apple documentation
+//        authorizer.authenticationSessionEmbedded
+        try doAuthorizeEmbedded(with: authConfig, params: params)
+        #elseif os(iOS)
 		if authConfig.authorizeEmbedded {
 			try doAuthorizeEmbedded(with: authConfig, params: params)
 		}
 		else {
 			try doOpenAuthorizeURLInBrowser(params: params)
 		}
+        #endif
 	}
 	
+    #if os(visionOS) // Intentionally blank per Apple documentation
+    #elseif os(iOS)
 	/**
 	Open the authorize URL in the OS's browser. Forwards to the receiver's `authorizer`, which is a platform-dependent implementation of
 	`OAuth2AuthorizerUI`.
@@ -240,6 +247,7 @@ open class OAuth2: OAuth2Base {
 		logger?.debug("OAuth2", msg: "Opening authorize URL in system browser: \(url)")
 		try authorizer.openAuthorizeURLInBrowser(url)
 	}
+    #endif
 	
 	/**
 	Tries to use the current auth config context, which on iOS should be a UIViewController and on OS X a NSViewController, to present the

--- a/Sources/Flows/OAuth2PasswordGrant.swift
+++ b/Sources/Flows/OAuth2PasswordGrant.swift
@@ -68,6 +68,7 @@ open class OAuth2PasswordGrant: OAuth2 {
 	
 	/// Properties used to handle the native controller.
 	open lazy var customAuthorizer: OAuth2CustomAuthorizerUI = OAuth2CustomAuthorizer()
+	
 	/**
 	If credentials are unknown when trying to authorize, the delegate will be asked a login controller to present.
 	

--- a/Sources/Flows/OAuth2PasswordGrant.swift
+++ b/Sources/Flows/OAuth2PasswordGrant.swift
@@ -23,7 +23,7 @@ import Foundation
  import Base
  #if os(macOS)
   import macOS
- #elseif os(iOS)
+ #elseif os(iOS) || os(visionOS)
   import iOS
  #elseif os(tvOS)
   import tvOS
@@ -68,7 +68,6 @@ open class OAuth2PasswordGrant: OAuth2 {
 	
 	/// Properties used to handle the native controller.
 	open lazy var customAuthorizer: OAuth2CustomAuthorizerUI = OAuth2CustomAuthorizer()
-	
 	/**
 	If credentials are unknown when trying to authorize, the delegate will be asked a login controller to present.
 	

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -17,7 +17,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-#if os(iOS)
+#if os(visionOS) || os(iOS)
 
 import UIKit
 import SafariServices

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -37,11 +37,11 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	/// The OAuth2 instance this authorizer belongs to.
 	public unowned let oauth2: OAuth2Base
 	
-    #if os(visionOS) // Intentionally blank per Apple documentation
-    #elseif os(iOS)
+	#if os(visionOS) // Intentionally blank per Apple documentation
+	#elseif os(iOS)
 	/// Used to store the `SFSafariViewControllerDelegate`.
 	private var safariViewDelegate: AnyObject?
-    #endif
+	#endif
 	
 	/// Used to store the authentication session.
 	private var authenticationSession: AnyObject?
@@ -56,8 +56,8 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	
 	// MARK: - OAuth2AuthorizerUI
 	
-    #if os(visionOS) // Intentionally blank per Apple documentation
-    #elseif os(iOS)
+	#if os(visionOS) // Intentionally blank per Apple documentation
+	#elseif os(iOS)
 	/**
 	Uses `UIApplication` to open the authorize URL in iOS's browser.
 	
@@ -74,8 +74,8 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 		throw OAuth2Error.unableToOpenAuthorizeURL
 		#endif
 	}
-    #endif
-    
+	#endif
+	
 	/**
 	Tries to use the current auth config context, which on iOS should be a UIViewController, to present the authorization screen.
 	
@@ -84,14 +84,14 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	- parameter at:   The authorize URL to open
 	*/
 	public func authorizeEmbedded(with config: OAuth2AuthConfig, at url: URL) throws {
-        #if os(visionOS) // visionOS must be first per Apple documentation
-        // On visionOS we can only use authentication session, so ignore any configs that say otherwise.
-        guard let redirect = oauth2.redirect else {
-            throw OAuth2Error.noRedirectURL
-        }
-        
-        authenticationSessionEmbedded(at: url, withRedirect: redirect, prefersEphemeralWebBrowserSession: config.ui.prefersEphemeralWebBrowserSession)
-        #elseif os(iOS)
+		#if os(visionOS) // visionOS must be first per Apple documentation
+		// On visionOS we can only use authentication session, so ignore any configs that say otherwise.
+		guard let redirect = oauth2.redirect else {
+			throw OAuth2Error.noRedirectURL
+		}
+		
+		authenticationSessionEmbedded(at: url, withRedirect: redirect, prefersEphemeralWebBrowserSession: config.ui.prefersEphemeralWebBrowserSession)
+		#elseif os(iOS)
 		if #available(iOS 11, *), config.ui.useAuthenticationSession {
 			guard let redirect = oauth2.redirect else {
 				throw OAuth2Error.noRedirectURL
@@ -120,7 +120,7 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 				}
 			}
 		}
-        #endif
+		#endif
 	}
 	
 	/**
@@ -200,8 +200,8 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 	
 	
 	// MARK: - Safari Web View Controller
-    #if os(visionOS) // Intentionally blank per Apple documentation
-    #elseif os(iOS)
+	#if os(visionOS) // Intentionally blank per Apple documentation
+	#elseif os(iOS)
 	/**
 	Presents a Safari view controller from the supplied view controller, loading the authorize URL.
 	
@@ -309,7 +309,7 @@ open class OAuth2Authorizer: OAuth2AuthorizerUI {
 		
 		return web
 	}
-    #endif
+	#endif
 }
 
 

--- a/Sources/iOS/OAuth2CustomAuthorizer+iOS.swift
+++ b/Sources/iOS/OAuth2CustomAuthorizer+iOS.swift
@@ -17,8 +17,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-#if os(iOS)
-
+#if os(visionOS) || os(iOS)
 import Foundation
 import UIKit
 #if !NO_MODULE_IMPORT
@@ -30,9 +29,7 @@ import Base
 An iOS and tvOS-specific implementation of the `OAuth2CustomAuthorizerUI` protocol which modally presents the login controller.
 */
 public class OAuth2CustomAuthorizer: OAuth2CustomAuthorizerUI {
-	
 	private var presentingController: UIViewController?
-	
 	public init() {  }
 	
 	

--- a/Sources/iOS/OAuth2CustomAuthorizer+iOS.swift
+++ b/Sources/iOS/OAuth2CustomAuthorizer+iOS.swift
@@ -29,7 +29,9 @@ import Base
 An iOS and tvOS-specific implementation of the `OAuth2CustomAuthorizerUI` protocol which modally presents the login controller.
 */
 public class OAuth2CustomAuthorizer: OAuth2CustomAuthorizerUI {
+
 	private var presentingController: UIViewController?
+	
 	public init() {  }
 	
 	

--- a/Sources/iOS/OAuth2WebViewController+iOS.swift
+++ b/Sources/iOS/OAuth2WebViewController+iOS.swift
@@ -17,7 +17,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-#if os(iOS)
+#if os(visionOS) // Intentionally blank per Apple documentation
+#elseif os(iOS)
 
 import UIKit
 import WebKit
@@ -102,7 +103,10 @@ open class OAuth2WebViewController: UIViewController, WKNavigationDelegate {
 	override open func loadView() {
 		edgesForExtendedLayout = .all
 		extendedLayoutIncludesOpaqueBars = true
+        #if os(visionOS) // Intentionally blank per Apple documentation
+        #elseif os(iOS)
 		automaticallyAdjustsScrollViewInsets = true
+        #endif
 		
 		super.loadView()
 		view.backgroundColor = UIColor.white

--- a/Sources/iOS/OAuth2WebViewController+iOS.swift
+++ b/Sources/iOS/OAuth2WebViewController+iOS.swift
@@ -103,10 +103,10 @@ open class OAuth2WebViewController: UIViewController, WKNavigationDelegate {
 	override open func loadView() {
 		edgesForExtendedLayout = .all
 		extendedLayoutIncludesOpaqueBars = true
-        #if os(visionOS) // Intentionally blank per Apple documentation
-        #elseif os(iOS)
+		#if os(visionOS) // Intentionally blank per Apple documentation
+		#elseif os(iOS)
 		automaticallyAdjustsScrollViewInsets = true
-        #endif
+		#endif
 		
 		super.loadView()
 		view.backgroundColor = UIColor.white


### PR DESCRIPTION
Many legacy authentication methods that OAuth2 supports are unavailable on visionOS. The only supported method is `ASWebAuthenticationSession`.

This PR compiles out the incompatible code, such as the `OAuth2WebViewController` and `SFSafariViewControllerDelegate`, allowing the visionOS app to compile and run. It also forces the `ASWebAuthenticationSession` method even if the configuration suggests otherwise.