### PR TITLE
Implement the device grant flow

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@ Contributors
 
 Contributors to the codebase, in reverse chronological order:
 
+- Dominik Paľo, @DominikPalo
 - Greg Price, @ObscureBug
 - Joseph Quigley, @josephquigley
 - Martin Pittenauer, @m4p

--- a/OAuth2.xcodeproj/project.pbxproj
+++ b/OAuth2.xcodeproj/project.pbxproj
@@ -30,6 +30,10 @@
 		65EC05E01C9050CB00DE9186 /* OAuth2KeychainAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EC05DF1C9050CB00DE9186 /* OAuth2KeychainAccount.swift */; };
 		65EC05E11C9050CB00DE9186 /* OAuth2KeychainAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EC05DF1C9050CB00DE9186 /* OAuth2KeychainAccount.swift */; };
 		65EC05E21C9050CB00DE9186 /* OAuth2KeychainAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EC05DF1C9050CB00DE9186 /* OAuth2KeychainAccount.swift */; };
+		8793811929D483EC00DC4EBC /* OAuth2DeviceGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793811829D483EC00DC4EBC /* OAuth2DeviceGrant.swift */; };
+		8793811A29D483EC00DC4EBC /* OAuth2DeviceGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793811829D483EC00DC4EBC /* OAuth2DeviceGrant.swift */; };
+		8793811B29D483EC00DC4EBC /* OAuth2DeviceGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793811829D483EC00DC4EBC /* OAuth2DeviceGrant.swift */; };
+		87B3E07C29F6AF240075C4DC /* OAuth2DeviceGrantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B3E07B29F6AF240075C4DC /* OAuth2DeviceGrantTests.swift */; };
 		CCCE40D6B4EAD9BF05C92ACE /* OAuth2CustomAuthorizer+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCE4C8DC3CB7713E59BC1EE /* OAuth2CustomAuthorizer+iOS.swift */; };
 		DD0CCBAD1C4DC83A0044C4E3 /* OAuth2WebViewController+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0CCBAC1C4DC83A0044C4E3 /* OAuth2WebViewController+macOS.swift */; };
 		EA9758181B222CEA007744B1 /* OAuth2PasswordGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9758171B222CEA007744B1 /* OAuth2PasswordGrant.swift */; };
@@ -168,6 +172,8 @@
 		6598543F1C5B3B4000237D39 /* OAuth2Authorizer+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "OAuth2Authorizer+tvOS.swift"; path = "Sources/tvOS/OAuth2Authorizer+tvOS.swift"; sourceTree = SOURCE_ROOT; };
 		659854461C5B3BEA00237D39 /* OAuth2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuth2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65EC05DF1C9050CB00DE9186 /* OAuth2KeychainAccount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2KeychainAccount.swift; sourceTree = "<group>"; };
+		8793811829D483EC00DC4EBC /* OAuth2DeviceGrant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2DeviceGrant.swift; sourceTree = "<group>"; };
+		87B3E07B29F6AF240075C4DC /* OAuth2DeviceGrantTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2DeviceGrantTests.swift; sourceTree = "<group>"; };
 		CCCE4C8DC3CB7713E59BC1EE /* OAuth2CustomAuthorizer+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OAuth2CustomAuthorizer+iOS.swift"; sourceTree = "<group>"; };
 		DD0CCBAC1C4DC83A0044C4E3 /* OAuth2WebViewController+macOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OAuth2WebViewController+macOS.swift"; sourceTree = "<group>"; };
 		EA9758171B222CEA007744B1 /* OAuth2PasswordGrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = OAuth2PasswordGrant.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -315,6 +321,7 @@
 			children = (
 				EE4EBD811D7FF38200E6A9CA /* OAuth2ClientCredentialsTests.swift */,
 				EE4EBD821D7FF38200E6A9CA /* OAuth2CodeGrantTests.swift */,
+				87B3E07B29F6AF240075C4DC /* OAuth2DeviceGrantTests.swift */,
 				EE4EBD831D7FF38200E6A9CA /* OAuth2DynRegTests.swift */,
 				EE4EBD841D7FF38200E6A9CA /* OAuth2ImplicitGrantTests.swift */,
 				EE4EBD851D7FF38200E6A9CA /* OAuth2PasswordGrantTests.swift */,
@@ -328,17 +335,18 @@
 			isa = PBXGroup;
 			children = (
 				EE29836F1D40B83600933CDD /* OAuth2.swift */,
-				EE3174EB1945E83100210E62 /* OAuth2ImplicitGrant.swift */,
-				EE44F691194F2C7D0094AB8B /* OAuth2CodeGrant.swift */,
-				0C2F5E5A1DE2DB8500F621E0 /* OAuth2CodeGrantAzure.swift */,
-				EEACE1DE1A7E8FC1009BF3A7 /* OAuth2CodeGrantFacebook.swift */,
-				EEC6D57B1C2837EA00FA9B1C /* OAuth2CodeGrantLinkedIn.swift */,
-				EE1391D91AC5B41A002C7B18 /* OAuth2CodeGrantBasicAuth.swift */,
-				EE86C4641C48F6AC00B7D486 /* OAuth2CodeGrantNoTokenType.swift */,
 				EE5F4F851B19114D00DB38B3 /* OAuth2ClientCredentials.swift */,
 				EEFD23501C9ED9E400727DCF /* OAuth2ClientCredentialsReddit.swift */,
-				EA9758171B222CEA007744B1 /* OAuth2PasswordGrant.swift */,
+				EE44F691194F2C7D0094AB8B /* OAuth2CodeGrant.swift */,
+				0C2F5E5A1DE2DB8500F621E0 /* OAuth2CodeGrantAzure.swift */,
+				EE1391D91AC5B41A002C7B18 /* OAuth2CodeGrantBasicAuth.swift */,
+				EEACE1DE1A7E8FC1009BF3A7 /* OAuth2CodeGrantFacebook.swift */,
+				EEC6D57B1C2837EA00FA9B1C /* OAuth2CodeGrantLinkedIn.swift */,
+				EE86C4641C48F6AC00B7D486 /* OAuth2CodeGrantNoTokenType.swift */,
+				8793811829D483EC00DC4EBC /* OAuth2DeviceGrant.swift */,
 				EE507A371B1E15E000AE02E9 /* OAuth2DynReg.swift */,
+				EE3174EB1945E83100210E62 /* OAuth2ImplicitGrant.swift */,
+				EA9758171B222CEA007744B1 /* OAuth2PasswordGrant.swift */,
 			);
 			path = Flows;
 			sourceTree = "<group>";
@@ -653,6 +661,7 @@
 				659854531C5B3CA700237D39 /* OAuth2ImplicitGrant.swift in Sources */,
 				659854501C5B3C9C00237D39 /* OAuth2Requestable.swift in Sources */,
 				6598544F1C5B3C9C00237D39 /* OAuth2Base.swift in Sources */,
+				8793811B29D483EC00DC4EBC /* OAuth2DeviceGrant.swift in Sources */,
 				EEB9A97E1D86C34E0022EF66 /* OAuth2Response.swift in Sources */,
 				EEFD23531C9ED9E400727DCF /* OAuth2ClientCredentialsReddit.swift in Sources */,
 				6598545A1C5B3CA700237D39 /* OAuth2PasswordGrant.swift in Sources */,
@@ -692,6 +701,7 @@
 				EE9EBF1C1D775F74003263FC /* OAuth2Securable.swift in Sources */,
 				EEF47D2C1B1E3FDD0057D838 /* OAuth2Requestable.swift in Sources */,
 				EEC49F321C9BF22400989A18 /* OAuth2AuthRequest.swift in Sources */,
+				8793811A29D483EC00DC4EBC /* OAuth2DeviceGrant.swift in Sources */,
 				EEC6D57D1C2837EA00FA9B1C /* OAuth2CodeGrantLinkedIn.swift in Sources */,
 				EE79F6551BFA93D900746243 /* OAuth2AuthConfig.swift in Sources */,
 				EEACE1D51A7E8DE8009BF3A7 /* OAuth2Base.swift in Sources */,
@@ -732,6 +742,7 @@
 				EE9EBF1B1D775F74003263FC /* OAuth2Securable.swift in Sources */,
 				EE79F65A1BFAA36900746243 /* OAuth2Error.swift in Sources */,
 				EEC49F311C9BF22400989A18 /* OAuth2AuthRequest.swift in Sources */,
+				8793811929D483EC00DC4EBC /* OAuth2DeviceGrant.swift in Sources */,
 				EE79F6571BFA945C00746243 /* OAuth2ClientConfig.swift in Sources */,
 				19C919DD1E51CC8000BFC834 /* OAuth2CustomAuthorizer+macOS.swift in Sources */,
 				EE79F6541BFA93D900746243 /* OAuth2AuthConfig.swift in Sources */,
@@ -769,6 +780,7 @@
 				EE4EBD891D7FF38200E6A9CA /* OAuth2ClientCredentialsTests.swift in Sources */,
 				EE4EBD8B1D7FF38200E6A9CA /* OAuth2DynRegTests.swift in Sources */,
 				EE4EBD8A1D7FF38200E6A9CA /* OAuth2CodeGrantTests.swift in Sources */,
+				87B3E07C29F6AF240075C4DC /* OAuth2DeviceGrantTests.swift in Sources */,
 				EEB9A9801D86CD4A0022EF66 /* OAuth2DataLoaderTests.swift in Sources */,
 				EE4EBD8C1D7FF38200E6A9CA /* OAuth2ImplicitGrantTests.swift in Sources */,
 				EE4EBD8E1D7FF38200E6A9CA /* OAuth2RefreshTokenTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -346,6 +346,13 @@ Instantiate `OAuth2ClientCredentials`, as usual supplying `client_id` but also a
 The _Resource Owner Password Credentials Grant_ is supported with the `OAuth2PasswordGrant` subclass.
 Create an instance as shown above, set its `username` and `password` properties, then call `authorize()`.
 
+### Device Grant
+
+The [OAuth 2.0 Device Authorization Grant](https://datatracker.ietf.org/doc/html/rfc8628) flow is implemented in the `OAuth2DeviceGrant` subclass.
+Although this flow is designed for devices that either lack a browser to perform a user-agent-based authorization or are input constrained, it is also very useful for applications not allowed to [start their own webserver (loopback URL) or register a custom URL scheme](https://www.oauth.com/oauth2-servers/redirect-uris/redirect-uris-native-apps/) to finish the authorization code grant flow.
+To initiate the device grant flow, the `deviceAuthorizeURL` needs to be correctly configured to point towards the device authorization endpoint. By calling the `OAuth2DeviceGrant.start(useNonTextualTransmission:params:completion:)` method, the client obtains [all necessary details](https://datatracker.ietf.org/doc/html/rfc8628#section-3.2) to complete the authorization on a secondary device or in the system browser.
+
+
 
 Site-Specific Peculiarities
 ---------------------------

--- a/Sources/Base/OAuth2Base.swift
+++ b/Sources/Base/OAuth2Base.swift
@@ -64,6 +64,11 @@ open class OAuth2Base: OAuth2Securable {
 	public final var authURL: URL {
 		get { return clientConfig.authorizeURL }
 	}
+    
+	/// The URL to obtain the device code.
+	public final var deviceAuthorizeURL: URL? {
+		get { return clientConfig.deviceAuthorizeURL }
+	}
 
 	/// The URL string where we can exchange a code for a token; if nil `authURL` will be used.
 	public final var tokenURL: URL? {

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -26,6 +26,9 @@ open class OAuth2ClientConfig {
 	/// The URL to authorize against.
 	public final let authorizeURL: URL
 	
+	/// The URL to obtain the device code.
+	public final var deviceAuthorizeURL: URL?
+	
 	/// The URL where we can exchange a code for a token.
 	public final var tokenURL: URL?
 
@@ -114,9 +117,12 @@ open class OAuth2ClientConfig {
 		}
 		authorizeURL = aURL ?? URL(string: "https://localhost/p2.OAuth2.defaultAuthorizeURI")!
 		
-		// token, registration and logo URLs
+		// token, device code, registration and logo URLs
 		if let token = settings["token_uri"] as? String {
 			tokenURL = URL(string: token)
+		}
+		if let deviceAuthorize = settings["device_authorize_uri"] as? String {
+			deviceAuthorizeURL = URL(string: deviceAuthorize)
 		}
 		if let refresh = settings["refresh_uri"] as? String {
 			refreshURL = URL(string: refresh)

--- a/Sources/Base/OAuth2Error.swift
+++ b/Sources/Base/OAuth2Error.swift
@@ -46,6 +46,9 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 	/// There is no client secret.
 	case noClientSecret
 	
+	/// There is no device code URL.
+	case noDeviceCodeURL
+	
 	/// There is no redirect URL.
 	case noRedirectURL
 	
@@ -159,7 +162,16 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 
 	/// Invalid grant. Passes the underlying error_description.
 	case invalidGrant(String?)
-
+	
+	/// The authorization request is still pending. Passes the underlying error_description.
+	case authorizationPending(String?)
+	
+	/// The authorization request is still pending, but the polling interval MUST be increased by 5 seconds. Passes the underlying error_description.
+	case slowDown(String?)
+	
+	/// The "device_code" has expired. Passes the underlying error_description.
+	case expiredToken(String?)
+	
 	/// Other response error, as defined in its String.
 	case responseError(String)
 	
@@ -190,6 +202,12 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 			return .temporarilyUnavailable(description)
 		case "invalid_grant":
 			return .invalidGrant(description)
+		case "authorization_pending":
+			return .authorizationPending(description)
+		case "slow_down":
+			return .slowDown(description)
+		case "expired_token":
+			return .expiredToken(description)
 		default:
 			return .responseError(description ?? fallback ?? "Authorization error: \(code)")
 		}
@@ -209,6 +227,8 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 			return "Client id not set"
 		case .noClientSecret:
 			return "Client secret not set"
+		case .noDeviceCodeURL:
+			return "Device code URL not set"
 		case .noRedirectURL:
 			return "Redirect URL not set"
 		case .noUsername:
@@ -282,6 +302,12 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 			return message ?? "The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server."
 		case .invalidGrant(let message):
 			return message ?? "The authorization grant or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
+		case .authorizationPending(let message):
+			return message ?? "The authorization request is still pending as the end user hasn't yet completed the user-interaction steps."
+		case .slowDown(let message):
+			return message ?? "The authorization request is still pending and polling should continue, but the interval must be increased by 5 seconds for this and all subsequent requests."
+		case .expiredToken(let message):
+			return message ?? "The \"device_code\" has expired, and the device authorization session has concluded."
 		case .responseError(let message):
 			return message
 		}
@@ -298,6 +324,7 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 		
 		case (.noClientId, .noClientId):                             return true
 		case (.noClientSecret, .noClientSecret):                     return true
+		case (.noDeviceCodeURL, .noDeviceCodeURL):                   return true
 		case (.noRedirectURL, .noRedirectURL):                       return true
 		case (.noUsername, .noUsername):                             return true
 		case (.noPassword, .noPassword):                             return true
@@ -332,6 +359,9 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 		case (.serverError, .serverError):                           return true
 		case (.temporarilyUnavailable(let lhm), .temporarilyUnavailable(let rhm)):     return lhm == rhm
 		case (.invalidGrant(let lhm), .invalidGrant(let rhm)):       return lhm == rhm
+		case (.authorizationPending, .authorizationPending):         return true
+		case (.slowDown, .slowDown):                                 return true
+		case (.expiredToken, .expiredToken):                         return true
 		case (.responseError(let lhm), .responseError(let rhm)):     return lhm == rhm
 		default:                                                     return false
 		}

--- a/Sources/Flows/OAuth2DeviceGrant.swift
+++ b/Sources/Flows/OAuth2DeviceGrant.swift
@@ -1,0 +1,196 @@
+//
+//  OAuth2DeviceGrant.swift
+//  OAuth2
+//
+//  Created by Dominik Paľo on 29/03/23.
+//  Copyright © 2023 Cisco Systems, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+#if !NO_MODULE_IMPORT
+import Base
+#endif
+
+/// https://www.ietf.org/rfc/rfc8628.html
+open class OAuth2DeviceGrant: OAuth2 {
+	override open class var grantType: String {
+		return "urn:ietf:params:oauth:grant-type:device_code"
+	}
+	
+	override open class var responseType: String? {
+		return ""
+	}
+		
+	open func deviceAccessTokenRequest(with deviceCode: String) throws -> OAuth2AuthRequest {
+		guard let clientId = clientConfig.clientId, !clientId.isEmpty else {
+			throw OAuth2Error.noClientId
+		}
+		
+		let req = OAuth2AuthRequest(url: (clientConfig.tokenURL ?? clientConfig.authorizeURL))
+		req.params["device_code"] = deviceCode
+		req.params["grant_type"] = type(of: self).grantType
+		req.params["client_id"] = clientId
+		return req
+	}
+	
+	open func deviceAuthorizationRequest(params: OAuth2StringDict? = nil) throws -> OAuth2AuthRequest {
+		guard let clientId = clientConfig.clientId, !clientId.isEmpty else {
+			throw OAuth2Error.noClientId
+		}
+		
+		guard let url = clientConfig.deviceAuthorizeURL else {
+			throw OAuth2Error.noDeviceCodeURL
+		}
+		
+		let req = OAuth2AuthRequest(url: url)
+		req.params["client_id"] = clientId
+		if let scope = clientConfig.scope {
+			req.params["scope"] = scope
+		}
+		req.add(params: params)
+		
+		return req
+	}
+	
+	open func parseDeviceAuthorizationResponse(data: Data) throws -> OAuth2JSON {
+		let dict = try parseJSON(data)
+		return try parseDeviceAuthorizationResponse(params: dict)
+	}
+	
+	public final func parseDeviceAuthorizationResponse(params: OAuth2JSON) throws -> OAuth2JSON {
+		try assureNoErrorInResponse(params)
+		
+		return params
+	}
+	
+	/**
+	Start the device authorization flow.
+	
+	- parameter params:   Optional key/value pairs to pass during authorize device request
+	- parameter callback: The callback to call after the device authorization response has been received
+	*/
+	public func start(useNonTextualTransmission: Bool = false, params: OAuth2StringDict? = nil, completion: @escaping (DeviceAuthorization?, Error?) -> Void) {
+		authorizeDevice(params: params) { result, error in
+			guard let result else {
+				if let error {
+					self.logger?.warn("OAuth2", msg: "Unable to get device code: \(error)")
+				}
+				completion(nil, error)
+				return
+			}
+			
+			guard let deviceCode = result["device_code"] as? String,
+				let userCode = result["user_code"] as? String,
+				let verificationUri = result["verification_uri"] as? String,
+				let verificationUrl = URL(string: verificationUri),
+				let expiresIn = result["expires_in"] as? Int else {
+				let error = OAuth2Error.generic("The response doesn't contain all required fields.")
+				self.logger?.warn("OAuth2", msg: String(describing: error))
+				completion(nil, error)
+				return
+			}
+			
+			var verificationUrlComplete: URL?
+			if let verificationUriComplete = result["verification_uri_complete"] as? String {
+				verificationUrlComplete = URL(string: verificationUriComplete)
+			}
+			
+			if useNonTextualTransmission, let url = verificationUrlComplete {
+				do {
+					try self.authorizer.openAuthorizeURLInBrowser(url)
+				} catch let error {
+					completion(nil, error)
+				}
+			}
+			
+			let pollingInterval = result["interval"] as? TimeInterval ?? 5
+			self.getDeviceAccessToken(deviceCode: deviceCode, interval: pollingInterval) { params, error in
+				if let params {
+					self.didAuthorize(withParameters: params)
+				}
+				else if let error {
+					self.didFail(with: error.asOAuth2Error)
+				}
+			}
+			
+			let deviceAuthorization = DeviceAuthorization(userCode: userCode, verificationUrl: verificationUrl, verificationUrlComplete: verificationUrlComplete, expiresIn: expiresIn)
+			completion(deviceAuthorization, nil)
+		}
+	}
+	
+	private func authorizeDevice(params: OAuth2StringDict?, completion: @escaping (OAuth2JSON?, Error?) -> Void) {
+		do {
+			let post = try deviceAuthorizationRequest(params: params).asURLRequest(for: self)
+			logger?.debug("OAuth2", msg: "Obtaining device code from \(post.url!)")
+			
+			perform(request: post) { response in
+				do {
+					let data = try response.responseData()
+					let params = try self.parseDeviceAuthorizationResponse(data: data)
+					completion(params, nil)
+				}
+				catch let error {
+					completion(nil, error.asOAuth2Error)
+				}
+			}
+		}
+		catch let error {
+			completion(nil, error.asOAuth2Error)
+		}
+	}
+	
+	private func getDeviceAccessToken(deviceCode: String, interval: TimeInterval, completion: @escaping (OAuth2JSON?, Error?) -> Void) {
+		do {
+			let post = try deviceAccessTokenRequest(with: deviceCode).asURLRequest(for: self)
+			logger?.debug("OAuth2", msg: "Obtaining access token for device with code \(deviceCode) from \(post.url!)")
+			
+			perform(request: post) { response in
+				do {
+					let data = try response.responseData()
+					let params = try self.parseAccessTokenResponse(data: data)
+					completion(params, nil)
+				}
+				catch let error {
+					let oaerror = error.asOAuth2Error
+					
+					if oaerror == .authorizationPending(nil) {
+						self.logger?.debug("OAuth2", msg: "AuthorizationPending, repeating in \(interval) seconds.")
+						DispatchQueue.main.asyncAfter(deadline: .now() + interval) {
+							self.getDeviceAccessToken(deviceCode: deviceCode, interval: interval, completion: completion)
+						}
+					} else if oaerror == .slowDown(nil) {
+						let updatedInterval = interval + 5 // The 5 seconds increase is required by the RFC8628 standard (https://www.rfc-editor.org/rfc/rfc8628#section-3.5)
+						self.logger?.debug("OAuth2", msg: "SlowDown, repeating in \(updatedInterval) seconds.")
+						DispatchQueue.main.asyncAfter(deadline: .now() + updatedInterval) {
+							self.getDeviceAccessToken(deviceCode: deviceCode, interval: updatedInterval, completion: completion)
+						}
+					} else {
+						completion(nil, oaerror)
+					}
+				}
+			}
+		}
+		catch let error {
+			completion(nil, error.asOAuth2Error)
+		}
+	}
+}
+
+public struct DeviceAuthorization {
+	public let userCode: String
+	public let verificationUrl: URL
+	public let verificationUrlComplete: URL?
+	public let expiresIn: Int
+}

--- a/Tests/FlowTests/OAuth2DeviceGrantTests.swift
+++ b/Tests/FlowTests/OAuth2DeviceGrantTests.swift
@@ -1,0 +1,196 @@
+//
+//  OAuth2DeviceGrantTests.swift
+//  OAuth2
+//
+//  Created by Dominik Paľo on 4/12/23.
+//  Copyright © 2023 Cisco Systems, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+#if !NO_MODULE_IMPORT
+@testable
+import Base
+@testable
+import Flows
+#else
+@testable
+import OAuth2
+#endif
+
+
+class OAuth2DeviceGrantTests: XCTestCase {
+	
+	lazy var baseSettings: OAuth2JSON = [
+		"client_id": "abc",
+		"authorize_uri": "https://auth.ful.io",
+		"device_authorize_uri": "https://auth.ful.io/device/code",
+		"token_uri": "https://token.ful.io",
+		"keychain": false,
+	]
+	
+	func testInit() {
+		let oauth = OAuth2DeviceGrant(settings: baseSettings)
+		XCTAssertEqual(oauth.clientId, "abc", "Must init `client_id`")
+		XCTAssertFalse(oauth.useKeychain, "No keychain")
+		XCTAssertNil(oauth.scope, "Empty scope")
+		
+		XCTAssertEqual(oauth.authURL, URL(string: "https://auth.ful.io")!, "Must init `authorize_uri`")
+		XCTAssertEqual(oauth.deviceAuthorizeURL, URL(string: "https://auth.ful.io/device/code")!, "Must init `device_authorize_uri`")
+		XCTAssertEqual(oauth.tokenURL!, URL(string: "https://token.ful.io")!, "Must init `token_uri`")
+	}
+	
+	func testDeviceAccessTokenRequest() {
+		let oauth = OAuth2DeviceGrant(settings: baseSettings)
+		
+		let req = try! oauth.deviceAccessTokenRequest(with: "pp").asURLRequest(for: oauth)
+		let comp = URLComponents(url: req.url!, resolvingAgainstBaseURL: true)!
+		XCTAssertEqual(comp.host!, "token.ful.io", "Correct host")
+		
+		let body = String(data: req.httpBody!, encoding: String.Encoding.utf8)
+		let query = OAuth2DeviceGrant.params(fromQuery: body!)
+		XCTAssertEqual(query["client_id"]!, "abc", "Expecting correct `client_id`")
+		XCTAssertEqual(query["grant_type"]!, "urn:ietf:params:oauth:grant-type:device_code", "Expecting correct `grant_type`")
+		XCTAssertEqual(query["device_code"]!, "pp", "Expecting correct `device_code`")
+	}
+	
+	func testDeviceAuthorizationRequest() {
+		let oauth = OAuth2DeviceGrant(settings: baseSettings)
+		
+		let req = try! oauth.deviceAuthorizationRequest().asURLRequest(for: oauth)
+		let comp = URLComponents(url: req.url!, resolvingAgainstBaseURL: true)!
+		XCTAssertEqual(comp.host!, "auth.ful.io", "Correct host")
+		
+		let body = String(data: req.httpBody!, encoding: String.Encoding.utf8)
+		let query = OAuth2DeviceGrant.params(fromQuery: body!)
+		XCTAssertEqual(query["client_id"]!, "abc", "Expecting correct `client_id`")
+	}
+	
+	func testDeviceAuthorizationRequestWithAdditionalParams() {
+		let oauth = OAuth2DeviceGrant(settings: baseSettings)
+		let additionalParams = ["test_param": "test_value"]
+		
+		let req = try! oauth.deviceAuthorizationRequest(params: additionalParams).asURLRequest(for: oauth)
+		let comp = URLComponents(url: req.url!, resolvingAgainstBaseURL: true)!
+		XCTAssertEqual(comp.host!, "auth.ful.io", "Correct host")
+		
+		let body = String(data: req.httpBody!, encoding: String.Encoding.utf8)
+		let query = OAuth2DeviceGrant.params(fromQuery: body!)
+		XCTAssertEqual(query["test_param"]!, "test_value", "Expecting correct `test_param`")
+	}
+	
+	func testDeviceAccessTokenResponse() {
+		let oauth = OAuth2DeviceGrant(settings: baseSettings)
+		var response = [
+			"access_token": "2YotnFZFEjr1zCsicMWpAA",
+			"expires_in": 3600,
+			"refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+			"foo": "bar & hat"
+		] as [String: Any]
+		
+		// must throw when "token_type" is missing
+		do {
+			_ = try oauth.parseAccessTokenResponse(params: response)
+			XCTAssertTrue(false, "Should not be here any more")
+		}
+		catch OAuth2Error.noTokenType {
+		}
+		catch let error {
+			XCTAssertNil(error, "Should not throw wrong error")
+		}
+		
+		// must throw when "token_type" is not known
+		response["token_type"] = "guardian"
+		do {
+			_ = try oauth.parseAccessTokenResponse(params: response)
+			XCTAssertTrue(false, "Should not be here any more")
+		}
+		catch OAuth2Error.unsupportedTokenType(_) {
+		}
+		catch let error {
+			XCTAssertNil(error, "Should not throw wrong error")
+		}
+		
+		// add "token_type"
+		response["token_type"] = "bearer"
+		do {
+			let dict = try oauth.parseAccessTokenResponse(params: response)
+			XCTAssertEqual("bar & hat", dict["foo"] as? String)
+			XCTAssertEqual("2YotnFZFEjr1zCsicMWpAA", oauth.accessToken, "Must extract access token")
+			XCTAssertNotNil(oauth.accessTokenExpiry, "Must extract access token expiry date")
+			XCTAssertEqual("tGzv3JOkF0XG5Qx2TlKWIA", oauth.refreshToken, "Must extract refresh token")
+		}
+		catch {
+			XCTAssertTrue(false, "Not expected to throw")
+		}
+		
+		// unsupported bearer type
+		let response2 = [
+			"access_token": "2YotnFZFEjr1zCsicMWpAA",
+			"token_type": "not_my_type",
+			"expires_in": 3600,
+			"refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+			"foo": "bar & hat"
+		] as [String : Any]
+		
+		do {
+			_ = try oauth.parseAccessTokenResponse(params: response2)
+			XCTAssertTrue(false, "Should not be here any more")
+		}
+		catch OAuth2Error.unsupportedTokenType {
+			XCTAssertTrue(true, "Throw correct error")
+		}
+		catch {
+			XCTAssertTrue(false, "Should not throw wrong error")
+		}
+		
+		let performer = OAuth2MockPerformer()
+		oauth.requestPerformer = performer
+		
+		// authorization_pending response
+		let responseAuthorizationPending = [
+			"error": "authorization_pending",
+			"error_description": "Anything..."
+		]
+		
+		do {
+			_ = try oauth.parseAccessTokenResponse(params: responseAuthorizationPending)
+			XCTAssertTrue(false, "Should not be here any more")
+		}
+		catch OAuth2Error.authorizationPending {
+			XCTAssertTrue(true, "Throw correct error")
+		}
+		catch {
+			XCTAssertTrue(false, "Should not throw wrong error")
+		}
+		
+		// slow_down response
+		let responseSlowDown = [
+			"error": "slow_down",
+			"error_description": "Anything..."
+		]
+		
+		do {
+			_ = try oauth.parseAccessTokenResponse(params: responseSlowDown)
+			XCTAssertTrue(false, "Should not be here any more")
+		}
+		catch OAuth2Error.slowDown {
+			XCTAssertTrue(true, "Throw correct error")
+		}
+		catch {
+			XCTAssertTrue(false, "Should not throw wrong error")
+		}
+	}
+}


### PR DESCRIPTION
This PR implements the device grant authorization flow (as described in the [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628)). Although this flow is designed for devices that either lack a browser to perform a user-agent-based authorization or are input constrained, it is also very useful for applications not allowed to [start their own webserver (loopback URL) or register a custom URL scheme](https://www.oauth.com/oauth2-servers/redirect-uris/redirect-uris-native-apps/) to finish the authorization code grant flow.

We've been using this implementation for several months (from our private fork) without any issues.